### PR TITLE
recoverylog: make playback hand-off fast & deterministic

### DIFF
--- a/consumer/database_test.go
+++ b/consumer/database_test.go
@@ -23,6 +23,9 @@ func (s *DatabaseSuite) TestDatabase(c *gc.C) {
 	fsm, err := recoverylog.NewFSM(recoverylog.FSMHints{Log: logName})
 	c.Assert(err, gc.IsNil)
 
+	author, err := recoverylog.NewRandomAuthorID()
+	c.Assert(err, gc.IsNil)
+
 	var result = journal.AsyncAppend{
 		Ready: make(chan struct{}),
 	}
@@ -35,7 +38,7 @@ func (s *DatabaseSuite) TestDatabase(c *gc.C) {
 	var opts = rocks.NewDefaultOptions()
 	defer opts.Destroy()
 
-	db, err := newDatabase(opts, fsm, path, writer)
+	db, err := newDatabase(opts, fsm, author, path, writer)
 
 	// Expect that database operations are being replicated to |logName|.
 	c.Check(err, gc.IsNil)

--- a/consumer/integration_test.go
+++ b/consumer/integration_test.go
@@ -253,7 +253,7 @@ func (s *ConsumerSuite) TestMasterWritesLastReadHints(c *gc.C) {
 	var runner = s.buildRunner(0, 1)
 	var initCh = make(chan struct{})
 
-	runner.ShardPreInitHook = func(shard Shard) {
+	runner.ShardPostInitHook = func(shard Shard) {
 		close(initCh)
 	}
 	var keysAPI = runner.KeysAPI()

--- a/consumer/pump_test.go
+++ b/consumer/pump_test.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	gc "github.com/go-check/check"
@@ -23,8 +24,12 @@ func (s *PumpSuite) TestPump(c *gc.C) {
 
 	// Return a result fixture which skips forward from 0 => 1234.
 	var getter journal.MockGetter
-	getter.On("Get", journal.ReadArgs{Journal: "a/journal", Offset: 0, Blocking: true}).
-		Return(journal.ReadResult{Offset: 1234}, reader).Once()
+	getter.On("Get", journal.ReadArgs{
+		Journal:  "a/journal",
+		Offset:   0,
+		Blocking: true,
+		Context:  context.TODO(),
+	}).Return(journal.ReadResult{Offset: 1234}, reader).Once()
 
 	var desc = &topic.Description{
 		GetMessage: func() topic.Message {

--- a/consumer/replica.go
+++ b/consumer/replica.go
@@ -38,12 +38,10 @@ func newReplica(shard *shard, runner *Runner, tree *etcd.Node) (*replica, error)
 func (r *replica) serve(runner *Runner) {
 	defer close(r.servingCh)
 
-	var err = r.player.Play(runner.Gazette)
-
-	if err != nil && err != recoverylog.ErrPlaybackCancelled {
+	if err := r.player.Play(runner.Gazette); err != nil {
 		log.WithFields(log.Fields{"shard": r.shard, "err": err}).Error("replication failed")
 		abort(runner, r.shard)
-		return
+	} else {
+		log.WithFields(log.Fields{"shard": r.shard}).Info("finished serving replica")
 	}
-	log.WithFields(log.Fields{"shard": r.shard, "err": err}).Info("finished serving replica")
 }

--- a/consumer/routines.go
+++ b/consumer/routines.go
@@ -127,8 +127,7 @@ func maybeEtcdSet(keysAPI etcd.KeysAPI, key string, value string) error {
 	var _, err = keysAPI.Set(context.Background(), key, value, nil)
 	// Etcd Set is best-effort.
 	if err != nil {
-		log.WithFields(log.Fields{"path": hintsPath, "err": err}).
-			Warn("failed to store hints")
+		log.WithFields(log.Fields{"key": key, "err": err}).Warn("failed to set etcd key")
 		return err
 	}
 	return nil
@@ -164,7 +163,9 @@ func LoadOffsetsFromEtcd(tree *etcd.Node) (map[journal.Name]int64, error) {
 	return result, nil
 }
 
-// Deprecated. Stores legacy |offsets| in Etcd.
+// Deprecated: We are removing support for offsets written to Etcd. Rocksdb
+// will be the sole source-of-truth for read offsets.
+// Stores legacy |offsets| in Etcd.
 func StoreOffsetsToEtcd(rootPath string, offsets map[journal.Name]int64, keysAPI etcd.KeysAPI) {
 	for name, offset := range offsets {
 		maybeEtcdSet(keysAPI, OffsetPath(rootPath, name), strconv.FormatInt(offset, 16))

--- a/consumer/routines.go
+++ b/consumer/routines.go
@@ -111,22 +111,24 @@ func loadHintsFromEtcd(shard ShardID, runner *Runner, tree *etcd.Node) (recovery
 	return hints, nil
 }
 
-// Stores |hints| in Etcd.
-func storeHintsToEtcd(hintsPath string, hints string, keysAPI etcd.KeysAPI) error {
-	_, err := keysAPI.Set(context.Background(), hintsPath, hints, nil)
+// hintsJSONString returns the JSON string encoding of |hints|.
+func hintsJSONString(hints recoverylog.FSMHints) string {
+	if b, err := json.Marshal(hints); err != nil {
+		panic(err.Error()) // JSON serialization of FSMHints can never fail.
+	} else {
+		return string(b)
+	}
+}
+
+// maybeEtcdSet attempts to set |key| to |value|, consuming an encountered error
+// by logging a warning. This routine simplifies usages making best-effort attempts
+// to write to Etcd which are permitted to fail.
+func maybeEtcdSet(keysAPI etcd.KeysAPI, key string, value string) error {
+	var _, err = keysAPI.Set(context.Background(), key, value, nil)
 	// Etcd Set is best-effort.
 	if err != nil {
 		log.WithFields(log.Fields{"path": hintsPath, "err": err}).
 			Warn("failed to store hints")
-		return err
-	}
-	return nil
-}
-
-func prepAndStoreHintsToEtcd(fsmHints recoverylog.FSMHints, hintsPath string, keysAPI etcd.KeysAPI) error {
-	if bb, err := json.Marshal(fsmHints); err != nil {
-		return err
-	} else if err := storeHintsToEtcd(hintsPath, string(bb), keysAPI); err != nil {
 		return err
 	}
 	return nil
@@ -162,17 +164,10 @@ func LoadOffsetsFromEtcd(tree *etcd.Node) (map[journal.Name]int64, error) {
 	return result, nil
 }
 
-// Stores legacy |offsets| in Etcd.
+// Deprecated. Stores legacy |offsets| in Etcd.
 func StoreOffsetsToEtcd(rootPath string, offsets map[journal.Name]int64, keysAPI etcd.KeysAPI) {
 	for name, offset := range offsets {
-		offsetPath := OffsetPath(rootPath, name)
-		_, err := keysAPI.Set(context.Background(), offsetPath,
-			strconv.FormatInt(offset, 16), nil)
-		// Etcd Set is best-effort.
-		if err != nil {
-			log.WithFields(log.Fields{"path": offsetPath, "err": err}).
-				Warn("failed to store offset")
-		}
+		maybeEtcdSet(keysAPI, OffsetPath(rootPath, name), strconv.FormatInt(offset, 16))
 	}
 }
 

--- a/consumer/routines_test.go
+++ b/consumer/routines_test.go
@@ -90,16 +90,7 @@ func (s *RoutinesSuite) TestStoreHintsToEtcd(c *gc.C) {
 	s.keysAPI.On("Set", mock.Anything, hintsPath, string(shard012),
 		mock.Anything).Return(&etcd.Response{}, nil)
 
-	storeHintsToEtcd(hintsPath, string(shard012), s.keysAPI)
-	s.keysAPI.AssertExpectations(c)
-}
-
-func (s *RoutinesSuite) TestPrepAndStoreHintsToEtcd(c *gc.C) {
-	hintsPath := "/foo/hints/shard-baz-012.lastRecovered"
-	shard012, _ := json.Marshal(s.hintsFixture())
-	s.keysAPI.On("Set", mock.Anything, hintsPath, string(shard012),
-		mock.Anything).Return(&etcd.Response{}, nil)
-	c.Assert(prepAndStoreHintsToEtcd(s.hintsFixture(), hintsPath, s.keysAPI), gc.IsNil)
+	maybeEtcdSet(s.keysAPI, hintsPath, hintsJSONString(s.hintsFixture()))
 	s.keysAPI.AssertExpectations(c)
 }
 

--- a/consumer/runner.go
+++ b/consumer/runner.go
@@ -45,7 +45,7 @@ type Runner struct {
 
 	// Optional hooks for notification of Shard lifecycle. These are largely
 	// intended to facilitate testing cases.
-	ShardPreInitHook     func(Shard)
+	ShardPostInitHook    func(Shard)
 	ShardPostConsumeHook func(topic.Envelope, Shard)
 	ShardPostCommitHook  func(Shard)
 	ShardPostStopHook    func(Shard)
@@ -188,7 +188,7 @@ func (r *Runner) ItemState(name string) string {
 		return UnknownShard
 	} else if shard.master != nil && shard.master.didFinishInit() {
 		return Primary
-	} else if shard.replica.player.IsAtLogHead() {
+	} else if shard.replica.player.IsTailing() {
 		return Ready
 	} else {
 		return Recovering

--- a/consumer/shard_index.go
+++ b/consumer/shard_index.go
@@ -23,7 +23,7 @@ type shardIndexEntry struct {
 // RegisterWithRunner registers the ShardIndex to watch the Runner,
 // indexing the live set of mastered Shards.
 func (i *ShardIndex) RegisterWithRunner(r *Runner) {
-	r.ShardPreInitHook = i.IndexShard
+	r.ShardPostInitHook = i.IndexShard
 	r.ShardPostStopHook = i.DeindexShard
 }
 

--- a/consumer/shard_index_test.go
+++ b/consumer/shard_index_test.go
@@ -11,7 +11,7 @@ func (s *ShardIndexSuite) TestRegistration(c *gc.C) {
 	var runner Runner
 	ind.RegisterWithRunner(&runner)
 
-	c.Check(runner.ShardPreInitHook, gc.NotNil)  // equals ind.addShard.
+	c.Check(runner.ShardPostInitHook, gc.NotNil) // equals ind.addShard.
 	c.Check(runner.ShardPostStopHook, gc.NotNil) // equals ind.removeShardAndWait.
 }
 

--- a/consumer/test_support.go
+++ b/consumer/test_support.go
@@ -57,8 +57,13 @@ func resetShard(runner *Runner, id ShardID, partition topic.Partition) error {
 	}
 	defer os.RemoveAll(localDir)
 
+	author, err := recoverylog.NewRandomAuthorID()
+	if err != nil {
+		return err
+	}
+
 	// Open the database & store offsets,
-	db, err := newDatabase(options, fsm, localDir, runner.Gazette)
+	db, err := newDatabase(options, fsm, author, localDir, runner.Gazette)
 	if err != nil {
 		return err
 	}

--- a/gazette/client.go
+++ b/gazette/client.go
@@ -154,6 +154,9 @@ func (c *Client) Head(args journal.ReadArgs) (journal.ReadResult, *url.URL) {
 	if err != nil {
 		return journal.ReadResult{Error: err}, nil
 	}
+	if args.Context != nil {
+		request = request.WithContext(args.Context)
+	}
 	response, err := c.Do(request)
 	if err != nil {
 		return journal.ReadResult{Error: err}, nil
@@ -168,6 +171,9 @@ func (c *Client) GetDirect(args journal.ReadArgs) (journal.ReadResult, io.ReadCl
 	request, err := http.NewRequest("GET", c.buildReadURL(args).String(), nil)
 	if err != nil {
 		return journal.ReadResult{Error: err}, nil
+	}
+	if args.Context != nil {
+		request = request.WithContext(args.Context)
 	}
 	response, err := c.Do(request)
 	if err != nil {

--- a/journal/io.go
+++ b/journal/io.go
@@ -69,14 +69,21 @@ type RetryReader struct {
 	Context context.Context
 }
 
-// NewRetryReader returns a RetryReader at |mark|, and using the provided
-// |getter| and |ctx| for all operations.
+// Deprecated: Use NewRetryReaderContext instead.
+// NewRetryReader returns a RetryReader at |mark|, using the provided
+// |getter| for all operations.
 func NewRetryReader(mark Mark, getter Getter) *RetryReader {
+	return NewRetryReaderContext(context.TODO(), mark, getter)
+}
+
+// NewRetryReaderContext returns a RetryReader at |mark|, using the provided
+// |getter| and |ctx| for all operations.
+func NewRetryReaderContext(ctx context.Context, mark Mark, getter Getter) *RetryReader {
 	return &RetryReader{
 		MarkedReader: MarkedReader{Mark: mark},
 		Blocking:     true,
 		Getter:       getter,
-		Context:      context.TODO(),
+		Context:      ctx,
 	}
 }
 

--- a/journal/io.go
+++ b/journal/io.go
@@ -2,19 +2,13 @@ package journal
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
-)
-
-// Effectively constants; mutable for test support.
-var (
-	retryReaderErrCooloff = 5 * time.Second
-	timeNow               = time.Now
 )
 
 // A MarkedReader delegates reads to an underlying reader, and maintains
@@ -32,7 +26,7 @@ func NewMarkedReader(mark Mark, r io.ReadCloser) *MarkedReader {
 }
 
 func (r *MarkedReader) Read(p []byte) (int, error) {
-	n, err := r.ReadCloser.Read(p)
+	var n, err = r.ReadCloser.Read(p)
 	r.Mark.Offset += int64(n)
 	return n, err
 }
@@ -48,7 +42,7 @@ func (r *MarkedReader) Close() error {
 }
 
 // AdjustedMark returns the current Mark adjusted for content read by |br|
-// (which must wrap this MarkedReader`) but unconsumed from |br|'s buffer.
+// (which must wrap this MarkedReader) but unconsumed from |br|'s buffer.
 func (r *MarkedReader) AdjustedMark(br *bufio.Reader) Mark {
 	return Mark{
 		Journal: r.Mark.Journal,
@@ -56,132 +50,158 @@ func (r *MarkedReader) AdjustedMark(br *bufio.Reader) Mark {
 	}
 }
 
-// A RetryReader masks encountered errors, transparently handling retries to
-// present its clients with an infinite-length bytestream which may block for
-// an arbitrarily long period of time.
+// RetryReader wraps a Getter and MarkedReader to provide callers with a
+// long-lived journal reader. RetryReader transparently handles and retries
+// errors, and will block as needed to await new journal content.
 type RetryReader struct {
+	// MarkedReader manages the current reader and offset tracking.
 	MarkedReader
-	// Duration RetryReader should block for new content before returning EOF.
-	// Specifically, RetryReader will issue reads with server deadline EOFTimeout,
-	// and return EOF on Read iff the read is server-closed with no content.
-	// If EOFTimeout is zero, EOF is never returned by Read.
-	EOFTimeout time.Duration
-	// Result of the most recent read.
-	Result ReadResult
-
-	getter  Getter
-	cooloff bool
+	// Whether read operations should block (the default). If Blocking is false,
+	// than Read operations may return ErrNotYetAvailable.
+	Blocking bool
+	// LastResult retains the result of the last journal read operation.
+	// Callers may access it to inspect metadata returned by the broker.
+	// It may be invalidated on every Read call.
+	LastResult ReadResult
+	// Getter against which to perform read operations.
+	Getter Getter
+	// Context to use in read operations issued to Getter.
+	Context context.Context
 }
 
+// NewRetryReader returns a RetryReader at |mark|, and using the provided
+// |getter| and |ctx| for all operations.
 func NewRetryReader(mark Mark, getter Getter) *RetryReader {
 	return &RetryReader{
 		MarkedReader: MarkedReader{Mark: mark},
-		getter:       getter,
+		Blocking:     true,
+		Getter:       getter,
+		Context:      context.TODO(),
 	}
 }
 
-func (rr *RetryReader) Read(p []byte) (int, error) {
-	if rr.cooloff {
-		time.Sleep(retryReaderErrCooloff)
-		rr.cooloff = false
-	}
+// Read returns the next available bytes of journal content, retrying as
+// required retry errors or await content to be written. Read will return
+// a non-nil error in the following cases:
+//  * If the RetryReader context is cancelled.
+//  * If Blocking is false, and ErrNotYetAvailable is returned by the broker.
+// All other errors are retried.
+func (rr *RetryReader) Read(p []byte) (n int, err error) {
+	for i := 0; true; i++ {
 
-	var firstRead bool
-
-	if rr.ReadCloser == nil {
-		firstRead = true // First read of the current reader.
-
-		if args, err := rr.open(); err != nil {
-			if err == ErrNotFound && args.Offset <= 0 {
-				// Initialization case: We're reading from the beginning of a journal
-				// which doesn't exist yet.
-				if rr.EOFTimeout != 0 {
-					return 0, io.EOF
+		// Handle a previously encountered error. Since we're a retrying reader,
+		// we consume and mask errors (possibly logging a warning), and manage
+		// our own back-off timer.
+		if err != nil {
+			switch err {
+			case ErrNotYetAvailable:
+				if !rr.Blocking {
+					return
+				} else {
+					// This RetryReader was in non-blocking mode but has since switched
+					// to blocking. Ignore this error and retry as a blocking operation.
 				}
-			} else if err != nil {
-				log.WithFields(log.Fields{"args": args, "err": rr.Result.Error}).Warn("open failed")
+			case io.EOF, context.DeadlineExceeded, context.Canceled:
+				// Suppress logging for expected errors.
+			case ErrNotFound:
+				if rr.MarkedReader.Mark.Offset <= 0 {
+					// Initialization case: We're reading from the beginning of a journal
+					// which doesn't exist yet.
+					break
+				}
+				fallthrough
+			default:
+				if rr.Context.Err() == nil {
+					log.WithFields(log.Fields{"mark": rr.MarkedReader.Mark, "err": err}).
+						Warn("Read failure (will retry)")
+				}
 			}
-			// Under the io.Reader contract, zero-length reads are allowed.
-			// The caller will retry.
-			return 0, nil
+
+			// Wait for a back-off timer, or context cancellation.
+			select {
+			case <-rr.Context.Done():
+				return 0, rr.Context.Err()
+			case <-time.After(backoff(i)):
+			}
+		}
+
+		if rr.MarkedReader.ReadCloser == nil {
+			var args = ReadArgs{
+				Journal:  rr.MarkedReader.Mark.Journal,
+				Offset:   rr.MarkedReader.Mark.Offset,
+				Blocking: rr.Blocking,
+				Context:  rr.Context,
+			}
+
+			rr.LastResult, rr.MarkedReader.ReadCloser = rr.Getter.Get(args)
+			if n, err = 0, rr.LastResult.Error; err != nil {
+				rr.MarkedReader.ReadCloser = nil
+				continue
+			}
+
+			if o := rr.MarkedReader.Mark.Offset; o != 0 && o != -1 && o != rr.LastResult.Offset {
+				// Offset jumps should be uncommon, but are possible if data has
+				// been removed from the middle of a journal.
+				log.WithFields(log.Fields{"mark": rr.MarkedReader.Mark, "result": rr.LastResult}).
+					Warn("offset jump")
+			}
+			rr.MarkedReader.Mark.Offset = rr.LastResult.Offset
+		}
+
+		if n, err = rr.MarkedReader.Read(p); err == nil {
+			return
+		} else {
+			// Close to nil rr.MarkedReader.ReadCloser.
+			rr.MarkedReader.Close()
+
+			if n != 0 {
+				// If data was returned with the error, squash |err|.
+				if err != io.EOF {
+					log.WithFields(log.Fields{"err": err, "n": n}).Warn("data read error (will retry)")
+				}
+				err = nil
+				return
+			}
 		}
 	}
-	n, err := rr.MarkedReader.Read(p)
-
-	if err == io.EOF {
-		rr.onError(false)
-
-		if firstRead && rr.EOFTimeout != 0 {
-			// We received a server EOF on a deadline request with no content.
-			// Pass through the EOF.
-			return n, io.EOF
-		}
-	} else if err != nil {
-		rr.onError(true)
-
-		// Log, but mask the error.
-		log.WithFields(log.Fields{"mark": rr.Mark, "err": err}).Warn("read failed")
-	}
-	return n, nil
+	panic("not reached")
 }
 
-func (rr *RetryReader) open() (ReadArgs, error) {
-	var args = ReadArgs{
-		Journal:  rr.Mark.Journal,
-		Offset:   rr.Mark.Offset,
-		Blocking: rr.EOFTimeout == 0,
-	}
-	if rr.EOFTimeout != 0 {
-		args.Deadline = timeNow().Add(rr.EOFTimeout)
-	}
-
-	rr.Result, rr.ReadCloser = rr.getter.Get(args)
-
-	if rr.Result.Error != nil {
-		rr.onError(true)
-		return args, rr.Result.Error
-	}
-
-	if o := rr.Mark.Offset; o != 0 && o != -1 && o != rr.Result.Offset {
-		// Offset jumps should be very uncommon, but are possible if data has
-		// been expunged from the middle of a journal.
-		log.WithFields(log.Fields{"mark": rr.Mark, "result": rr.Result}).Warn("offset jump")
-	}
-	rr.Mark.Offset = rr.Result.Offset
-	return args, nil
-}
-
+// Seek sets the offset for the next Read. It returns an error if (and only if)
+// |whence| is io.SeekEnd, which is not supported.
 func (rr *RetryReader) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
-	case os.SEEK_SET:
-		// |offset| is absolute.
-	case os.SEEK_CUR:
-		offset = rr.Mark.Offset + offset
+	case io.SeekStart:
+		// |offset| is already absolute.
+	case io.SeekCurrent:
+		offset = rr.MarkedReader.Mark.Offset + offset
 	default:
-		// SEEK_END is not supported.
-		return rr.Mark.Offset, errors.New("invalid whence")
+		return rr.MarkedReader.Mark.Offset, errors.New("io.SeekEnd whence is not supported")
 	}
 
-	var delta = offset - rr.Mark.Offset
-	rr.Mark.Offset = offset
+	var delta = offset - rr.MarkedReader.Mark.Offset
 
-	if rr.ReadCloser == nil || delta < 0 || offset >= rr.Result.Fragment.End {
-		// Seek cannot be satisfied with the open reader. Close to retry.
-		rr.onError(false)
-		return rr.Mark.Offset, nil
-	}
-
-	if _, err := io.CopyN(ioutil.Discard, rr.ReadCloser, delta); err != nil {
+	if rr.MarkedReader.ReadCloser == nil || delta < 0 || offset >= rr.LastResult.Fragment.End {
+		// Seek cannot be satisfied with the open reader.
+		rr.MarkedReader.Close()
+	} else if _, err := io.CopyN(ioutil.Discard, rr.MarkedReader.ReadCloser, delta); err != nil {
 		log.WithFields(log.Fields{"delta": delta, "err": err}).Warn("seeking reader")
-		return rr.Mark.Offset, rr.Close() // Close to retry.
+		rr.MarkedReader.Close()
 	}
 
-	return rr.Mark.Offset, nil
+	rr.MarkedReader.Mark.Offset = offset
+	return offset, nil
 }
 
-func (rr *RetryReader) onError(shouldCooloff bool) {
-	if err := rr.MarkedReader.Close(); err != nil {
-		log.WithField("err", err).Warn("marked reader close failed")
+func backoff(attempt int) time.Duration {
+	switch attempt {
+	case 0, 1:
+		return 0
+	case 2:
+		return time.Millisecond * 5
+	case 3, 4, 5:
+		return time.Second * time.Duration(attempt-1)
+	default:
+		return 5 * time.Second
 	}
-	rr.cooloff = shouldCooloff
 }

--- a/journal/io_test.go
+++ b/journal/io_test.go
@@ -76,8 +76,7 @@ func (s *IOSuite) TestReaderRetries(c *gc.C) {
 	var ctx, cancel = context.WithCancel(context.Background())
 	var getter = new(MockGetter)
 
-	var rr = NewRetryReader(Mark{"a/journal", -1}, getter)
-	rr.Context = ctx
+	var rr = NewRetryReaderContext(ctx, Mark{"a/journal", -1}, getter)
 	rr.Blocking = false
 
 	// Initial read of 3 bytes, which increments the offset from 0 -> 100 and then EOFs.
@@ -157,8 +156,7 @@ func (s *IOSuite) TestSeeking(c *gc.C) {
 
 	var getter = new(MockGetter)
 	var ctx = context.Background()
-	var rr = NewRetryReader(Mark{"a/journal", 0}, getter)
-	rr.Context = ctx
+	var rr = NewRetryReaderContext(ctx, Mark{"a/journal", 0}, getter)
 
 	var checkRead = func(expect string) {
 		var buffer = make([]byte, len(expect))

--- a/journal/io_test.go
+++ b/journal/io_test.go
@@ -1,29 +1,30 @@
 package journal
 
 import (
+	"bufio"
+	"context"
 	"io"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing/iotest"
-	"time"
 
 	gc "github.com/go-check/check"
+	"github.com/stretchr/testify/mock"
 )
 
 type IOSuite struct{}
 
 func (s *IOSuite) TestMarkedReaderUpdates(c *gc.C) {
-	reader := struct {
+	var reader = struct {
 		io.Reader
 		closeCh
 	}{iotest.TimeoutReader(iotest.HalfReader(strings.NewReader("afixture"))), make(closeCh)}
 
-	mr := NewMarkedReader(Mark{Journal: "a/journal", Offset: 1234}, reader)
+	var mr = NewMarkedReader(Mark{Journal: "a/journal", Offset: 1234}, reader)
 	var buffer [8]byte
 
 	// First read: read succeeds at half of the request size.
-	n, err := mr.Read(buffer[:6])
+	var n, err = mr.Read(buffer[:6])
 	c.Check(n, gc.Equals, 3)
 	c.Check(err, gc.IsNil)
 
@@ -41,54 +42,100 @@ func (s *IOSuite) TestMarkedReaderUpdates(c *gc.C) {
 	<-reader.closeCh // Expect Close() to have been called.
 }
 
-func (s *IOSuite) TestReaderRetries(c *gc.C) {
-	oldCooloff := retryReaderErrCooloff
-	defer func() { retryReaderErrCooloff = oldCooloff }()
-	retryReaderErrCooloff = time.Nanosecond
+func (s *IOSuite) TestBufferedMarkAdjustment(c *gc.C) {
+	var reader = struct {
+		io.Reader
+		closeCh
+	}{strings.NewReader("foobar\nbaz\n"), make(closeCh)}
 
+	var mr = NewMarkedReader(Mark{Journal: "a/journal", Offset: 1234}, reader)
+	var br = bufio.NewReader(mr)
+
+	var b, err = br.ReadBytes('\n')
+	c.Check(string(b), gc.Equals, "foobar\n")
+	c.Check(err, gc.IsNil)
+
+	// Expect the entire input reader was consumed.
+	c.Check(mr.Mark.Offset, gc.Equals, int64(1234+7+4))
+	// Expect the adjusted mark reflects just the portion read from |br|.
+	c.Check(mr.AdjustedMark(br).Offset, gc.Equals, int64(1234+7))
+}
+
+func (s *IOSuite) TestReaderRetries(c *gc.C) {
 	// Sequence of test readers which will be returned by sequential Get's.
-	readers := []struct {
+	var readers = []struct {
 		io.Reader
 		closeCh
 	}{
-		{iotest.OneByteReader(strings.NewReader("foo")), make(closeCh)},
+		{iotest.DataErrReader(iotest.OneByteReader(strings.NewReader("foo"))), make(closeCh)},
 		{iotest.TimeoutReader(iotest.HalfReader(strings.NewReader("barbaXXX"))), make(closeCh)},
 		{strings.NewReader(""), make(closeCh)},
 		{iotest.HalfReader(strings.NewReader("zbingYYY")), make(closeCh)},
 	}
 
-	// Initial read of 3 bytes, which increments the offset from 0 and then EOFs.
-	getter := &MockGetter{}
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: -1, Blocking: true}).
+	var ctx, cancel = context.WithCancel(context.Background())
+	var getter = new(MockGetter)
+
+	var rr = NewRetryReader(Mark{"a/journal", -1}, getter)
+	rr.Context = ctx
+	rr.Blocking = false
+
+	// Initial read of 3 bytes, which increments the offset from 0 -> 100 and then EOFs.
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: -1, Blocking: false, Context: ctx}).
 		Return(ReadResult{Offset: 100}, readers[0]).Once()
 
 	// Next open fails.
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 103, Blocking: true}).
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 103, Blocking: false, Context: ctx}).
 		Return(ReadResult{Error: ErrNotBroker}, ioutil.NopCloser(nil)).Once()
 
+	// Read is retried, and the ErrNotYetAvailable is surfaced to the caller.
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 103, Blocking: false, Context: ctx}).
+		Return(ReadResult{Error: ErrNotYetAvailable}, ioutil.NopCloser(nil)).Once()
+
+	// Expect |rr| is switched to blocking. Next ErrNotYetAvailable is swallowed and retried.
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 103, Blocking: true, Context: ctx}).
+		Return(ReadResult{Error: ErrNotYetAvailable}, ioutil.NopCloser(nil)).Once()
+
 	// Next open jumps the offset, reads 5 bytes, then times out.
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 103, Blocking: true}).
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 103, Blocking: true, Context: ctx}).
 		Return(ReadResult{Offset: 203}, readers[1]).Once()
 
-	// Next open returns a reader which immediately EOFs.
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 208, Blocking: true}).
+	// Next open returns a reader which EOFs without content.
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 208, Blocking: true, Context: ctx}).
 		Return(ReadResult{Offset: 208}, readers[2]).Once()
 
 	// Next open reads remaining 5 bytes at the updated offset.
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 208, Blocking: true}).
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 208, Blocking: true, Context: ctx}).
 		Return(ReadResult{Offset: 208}, readers[3]).Once()
+
+	// All subsequent reads return an error.
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 216, Blocking: true, Context: ctx}).
+		Run(func(mock.Arguments) { cancel() }). // Side effect: cancel the Context.
+		Return(ReadResult{Error: ErrNotBroker}, ioutil.NopCloser(nil))
 
 	var recovered [13]byte
 
-	rr := NewRetryReader(Mark{"a/journal", -1}, getter)
+	// ReadFull drives required Gets. Expect the non-blocking ErrNotYetAvailable was surfaced.
+	var n, err = io.ReadFull(rr, recovered[:])
+	c.Check(n, gc.Equals, 3)
+	c.Check(err, gc.Equals, ErrNotYetAvailable)
+	c.Check(rr.Mark.Offset, gc.Equals, int64(103))
 
-	// Expect that ReadFull() drives required Get()s and completes without error.
-	n, err := io.ReadFull(rr, recovered[:])
-	c.Check(rr.Mark.Offset, gc.Equals, int64(213))
+	rr.Blocking = true
 
-	c.Check(n, gc.Equals, 13)
+	// Re-enter the read. Expect it succeeds.
+	n, err = io.ReadFull(rr, recovered[n:])
+	c.Check(n, gc.Equals, 10)
 	c.Check(string(recovered[:]), gc.Equals, "foobarbazbing")
 	c.Check(err, gc.IsNil)
+	c.Check(rr.Mark.Offset, gc.Equals, int64(213))
+
+	// Next read attempt will fail with a cancelled Context.
+	n, err = io.ReadFull(rr, recovered[:])
+	c.Check(n, gc.Equals, 3)
+	c.Check(string(recovered[:3]), gc.Equals, "YYY")
+	c.Check(err, gc.Equals, context.Canceled)
+	c.Check(rr.Mark.Offset, gc.Equals, int64(216))
 
 	// Expect all readers were closed.
 	c.Check(rr.Close(), gc.IsNil)
@@ -98,53 +145,8 @@ func (s *IOSuite) TestReaderRetries(c *gc.C) {
 	}
 }
 
-func (s *IOSuite) TestEOFTimeout(c *gc.C) {
-	defer func() {
-		timeNow = time.Now
-	}()
-	timeNow = func() time.Time { return time.Unix(1234, 0) }
-
-	// Sequence of test readers which will be returned by sequential Get's.
-	readers := []struct {
-		io.Reader
-		closeCh
-	}{
-		{strings.NewReader("foo"), make(closeCh)},
-		{strings.NewReader(""), make(closeCh)},
-	}
-
-	getter := &MockGetter{}
-	rr := NewRetryReader(Mark{"a/journal", 0}, getter)
-	rr.EOFTimeout = time.Second
-
-	// Initial read opens reader.
-	deadline := time.Unix(1234, 0).Add(time.Second)
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 0, Deadline: deadline}).
-		Return(ReadResult{Offset: 100}, readers[0]).Once()
-
-	var buffer [12]byte
-
-	n, err := rr.Read(buffer[:])
-	c.Check(n, gc.Equals, 3)
-	c.Check(string(buffer[:n]), gc.Equals, "foo")
-	c.Check(err, gc.IsNil)
-
-	// Next Read gets EOF, and silently closes.
-	n, err = rr.Read(buffer[:])
-	c.Check(n, gc.Equals, 0)
-	c.Check(err, gc.IsNil)
-
-	// Final Read opens a new empty reader. Error is passed through.
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 103, Deadline: deadline}).
-		Return(ReadResult{Offset: 103}, readers[1]).Once()
-
-	n, err = rr.Read(buffer[:])
-	c.Check(n, gc.Equals, 0)
-	c.Check(err, gc.Equals, io.EOF)
-}
-
 func (s *IOSuite) TestSeeking(c *gc.C) {
-	readers := []struct {
+	var readers = []struct {
 		io.Reader
 		closeCh
 	}{
@@ -153,25 +155,27 @@ func (s *IOSuite) TestSeeking(c *gc.C) {
 		{strings.NewReader("xyz"), make(closeCh)},
 	}
 
-	getter := &MockGetter{}
-	rr := NewRetryReader(Mark{"a/journal", 0}, getter)
+	var getter = new(MockGetter)
+	var ctx = context.Background()
+	var rr = NewRetryReader(Mark{"a/journal", 0}, getter)
+	rr.Context = ctx
 
-	checkRead := func(expect string) {
+	var checkRead = func(expect string) {
 		var buffer = make([]byte, len(expect))
 
-		n, err := rr.Read(buffer[:])
+		var n, err = rr.Read(buffer[:])
 		c.Check(n, gc.Equals, len(expect))
 		c.Check(err, gc.IsNil)
 		c.Check(string(buffer[:n]), gc.Equals, expect)
 	}
 
 	// Seek of a closed reader just updates the offset.
-	n, err := rr.Seek(100, os.SEEK_SET)
+	var n, err = rr.Seek(100, io.SeekStart)
 	c.Check(n, gc.Equals, int64(100))
 	c.Check(err, gc.IsNil)
 
 	// Initial read opens reader.
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 100, Blocking: true}).
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 100, Blocking: true, Context: ctx}).
 		Return(ReadResult{
 			Offset:   100,
 			Fragment: Fragment{End: 111},
@@ -181,7 +185,7 @@ func (s *IOSuite) TestSeeking(c *gc.C) {
 	checkRead("abc")
 
 	// Seek forward 3 bytes. It's satisfied by the current reader.
-	n, err = rr.Seek(3, os.SEEK_CUR)
+	n, err = rr.Seek(3, io.SeekCurrent)
 	c.Check(n, gc.Equals, int64(106))
 	c.Check(err, gc.IsNil)
 	c.Check(rr.ReadCloser, gc.NotNil)
@@ -190,13 +194,13 @@ func (s *IOSuite) TestSeeking(c *gc.C) {
 	checkRead("ghi")
 
 	// Seek forward 2 bytes. Cannot be satisfied by the current reader.
-	n, err = rr.Seek(2, os.SEEK_CUR)
+	n, err = rr.Seek(2, io.SeekCurrent)
 	c.Check(n, gc.Equals, int64(111))
 	c.Check(err, gc.IsNil)
 	c.Check(rr.ReadCloser, gc.IsNil)
 
 	// Next Read issues a new request.
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 111, Blocking: true}).
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 111, Blocking: true, Context: ctx}).
 		Return(ReadResult{
 			Offset:   111,
 			Fragment: Fragment{End: 117},
@@ -205,20 +209,20 @@ func (s *IOSuite) TestSeeking(c *gc.C) {
 	checkRead("foo")
 
 	// Seek backward 1 byte. Backward seeks force a re-open.
-	n, err = rr.Seek(-1, os.SEEK_CUR)
+	n, err = rr.Seek(-1, io.SeekCurrent)
 	c.Check(n, gc.Equals, int64(113))
 	c.Check(err, gc.IsNil)
 	c.Check(rr.ReadCloser, gc.IsNil)
 
-	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 113, Blocking: true}).
+	getter.On("Get", ReadArgs{Journal: "a/journal", Offset: 113, Blocking: true, Context: ctx}).
 		Return(ReadResult{Offset: 113, Fragment: Fragment{End: 116}}, readers[2]).Once()
 
 	checkRead("xyz")
 
-	// SEEK_END is not supported.
-	n, err = rr.Seek(-1, os.SEEK_END)
+	// io.SeekEnd is not supported.
+	n, err = rr.Seek(-1, io.SeekEnd)
 	c.Check(n, gc.Equals, int64(116)) // Not modified.
-	c.Check(err, gc.ErrorMatches, "invalid whence")
+	c.Check(err, gc.ErrorMatches, "io.SeekEnd whence is not supported")
 }
 
 type closeCh chan struct{}

--- a/journal/memory_broker.go
+++ b/journal/memory_broker.go
@@ -72,7 +72,7 @@ func (j *MemoryBroker) Get(args ReadArgs) (ReadResult, io.ReadCloser) {
 		args.Offset = int64(buf.Len())
 	}
 
-	for i := 0; true; i++ {
+	for {
 		if int(args.Offset) < buf.Len() {
 			return ReadResult{
 				Offset:    args.Offset,

--- a/journal/memory_broker.go
+++ b/journal/memory_broker.go
@@ -1,0 +1,131 @@
+package journal
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"sync"
+)
+
+// MemoryBroker provides an in-memory implementation of the Client interface.
+// The intended use is within unit tests which exercise components coordinating
+// through the Client interface.
+type MemoryBroker struct {
+	// DelayWrites indicates that writes should queue (and their promises not resolve) until:
+	//   * The next explicit Flush, or
+	//   * DelayWrites is set to false and another Write occurs.
+	DelayWrites bool
+	// Content written to each journal.
+	Content map[Name]*bytes.Buffer
+	// Pending content which will be written on the next Flush (or write, if !DelayWrites).
+	Pending map[Name]*bytes.Buffer
+
+	// Next promise which will resolve on the next write flush.
+	promise chan struct{}
+	// |cond| signals to blocked Get operations that content may be available.
+	cond *sync.Cond
+	mu   sync.Mutex
+}
+
+// NewMemoryBroker returns an initialized, zero-value MemoryBroker.
+func NewMemoryBroker() *MemoryBroker {
+	var j = &MemoryBroker{
+		Content: make(map[Name]*bytes.Buffer),
+		Pending: make(map[Name]*bytes.Buffer),
+		promise: make(chan struct{}),
+	}
+	j.cond = sync.NewCond(&j.mu)
+
+	return j
+}
+
+func (j *MemoryBroker) Write(name Name, b []byte) (*AsyncAppend, error) {
+	return j.ReadFrom(name, bytes.NewReader(b))
+}
+
+func (j *MemoryBroker) ReadFrom(name Name, r io.Reader) (*AsyncAppend, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	var cur, next = obtainBuffer(name, j.Content), obtainBuffer(name, j.Pending)
+	var _, err = next.ReadFrom(r)
+
+	var result = &AsyncAppend{
+		Ready:        j.promise,
+		AppendResult: AppendResult{WriteHead: int64(cur.Len() + next.Len())},
+	}
+
+	if !j.DelayWrites {
+		j.flush()
+	}
+	return result, err
+}
+
+func (j *MemoryBroker) Get(args ReadArgs) (ReadResult, io.ReadCloser) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	var buf = obtainBuffer(args.Journal, j.Content)
+
+	if args.Offset == -1 {
+		args.Offset = int64(buf.Len())
+	}
+
+	for i := 0; true; i++ {
+		if int(args.Offset) < buf.Len() {
+			return ReadResult{
+				Offset:    args.Offset,
+				WriteHead: int64(buf.Len()),
+				Fragment:  Fragment{Begin: 0, End: int64(buf.Len())},
+			}, ioutil.NopCloser(bytes.NewReader(buf.Bytes()[args.Offset:]))
+		} else if !args.Blocking {
+			return ReadResult{
+				Error:     ErrNotYetAvailable,
+				WriteHead: int64(buf.Len()),
+			}, nil
+		} else if err := args.Context.Err(); err != nil {
+			return ReadResult{Error: err}, nil
+		}
+
+		j.cond.Wait()
+	}
+	panic("not reached")
+}
+
+func (j *MemoryBroker) Head(args ReadArgs) (ReadResult, *url.URL) {
+	panic("not yet implemented")
+}
+
+func (j *MemoryBroker) Create(journal Name) error {
+	panic("not yet implemented")
+}
+
+// Flush resolves all pending writes and wakes any blocked read operations.
+func (j *MemoryBroker) Flush() {
+	j.mu.Lock()
+	j.flush()
+	j.mu.Unlock()
+}
+
+func (j *MemoryBroker) flush() {
+	defer j.cond.Broadcast()
+
+	var promise = j.promise
+	j.promise = make(chan struct{})
+	defer close(promise)
+
+	for name, src := range j.Pending {
+		obtainBuffer(name, j.Content).ReadFrom(src)
+		src.Reset()
+	}
+}
+
+func obtainBuffer(name Name, m map[Name]*bytes.Buffer) *bytes.Buffer {
+	var buf, ok = m[name]
+	if !ok {
+		buf = new(bytes.Buffer)
+		m[name] = buf
+	}
+	return buf
+}

--- a/journal/protocol.go
+++ b/journal/protocol.go
@@ -72,7 +72,7 @@ type ReadArgs struct {
 	// values specify a desired exact byte offset to read from. If the offset is
 	// not available (eg, because it represents a portion of Journal which has
 	// been permantently deleted), the broker will return the next available
-	// offset. Callers should therefor always inspect the ReadResult Offset.
+	// offset. Callers should therefore always inspect the ReadResult Offset.
 	Offset int64
 	// Whether the operation should block until content becomes available.
 	// ErrNotYetAvailable is returned if a non-blocking read has no ready content.
@@ -80,9 +80,9 @@ type ReadArgs struct {
 	// Context which may cancel or supply a deadline for the operation.
 	Context context.Context
 
-	// The time at which blocking will expire
-	// DEPRECATED. Server-side support for deadlines will be removed. Use
+	// Deprecated: Server-side support for deadlines will be removed. Use
 	// context.WithDeadline instead.
+	// The time at which blocking will expire
 	Deadline time.Time
 }
 

--- a/journal/protocol.go
+++ b/journal/protocol.go
@@ -1,6 +1,7 @@
 package journal
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -66,24 +67,28 @@ type ReplicateOp struct {
 
 type ReadArgs struct {
 	Journal Name
-	// Offset to begin reading from. Values 0 and -1 have special handling:
-	//  * If 0, the read is performed at the first available journal offset.
-	//  * If -1, then the read is performed from the current write head.
-	// All other values specify an exact byte offset which must be read from.
+	// Desired offset to begin reading from. Value -1 has special handling, where
+	// the read is performed from the current write head. All other positive
+	// values specify a desired exact byte offset to read from. If the offset is
+	// not available (eg, because it represents a portion of Journal which has
+	// been permantently deleted), the broker will return the next available
+	// offset. Callers should therefor always inspect the ReadResult Offset.
 	Offset int64
-	// DEPRECATED.  To be replaced by |Deadline|.  Whether this operation should
-	// block until the requested offset becomes available.
+	// Whether the operation should block until content becomes available.
+	// ErrNotYetAvailable is returned if a non-blocking read has no ready content.
 	Blocking bool
+	// Context which may cancel or supply a deadline for the operation.
+	Context context.Context
+
 	// The time at which blocking will expire
+	// DEPRECATED. Server-side support for deadlines will be removed. Use
+	// context.WithDeadline instead.
 	Deadline time.Time
 }
 
 type ReadResult struct {
 	Error error
-	// The effective |Offset| of the operation. It will differ from
-	// ReadOp.Offset only for special requested values 0 and -1:
-	//  * If 0, |Offset| reflects the first available offset.
-	//  * If -1, |Offset| reflects the write head at operation start.
+	// The effective offset of the operation.
 	Offset int64
 	// Write head at the completion of the operation.
 	WriteHead int64

--- a/recoverylog/fsm.go
+++ b/recoverylog/fsm.go
@@ -75,7 +75,7 @@ type FSM struct {
 
 func NewFSM(hints FSMHints) (*FSM, error) {
 	var fsm = &FSM{
-		LogMark:      journal.NewMark(hints.Log, -1),
+		LogMark:      journal.NewMark(hints.Log, 0),
 		NextSeqNo:    1,
 		NextChecksum: 0,
 		Properties:   make(map[string]string),

--- a/recoverylog/fsm_test.go
+++ b/recoverylog/fsm_test.go
@@ -45,7 +45,7 @@ func (s *FSMSuite) TestInitializationFromHints(c *gc.C) {
 	}
 	s.fsm = s.newFSM(c, hints)
 
-	c.Check(s.fsm.LogMark, gc.Equals, journal.NewMark("a/log", -1))
+	c.Check(s.fsm.LogMark, gc.Equals, journal.NewMark("a/log", 0))
 	c.Check(s.fsm.hintedSegments[0].FirstOffset, gc.Equals, int64(1234))
 	s.fsm.LogMark.Offset = 1234 // Skip FSM forward to FirstOffset.
 

--- a/recoverylog/integration_test.go
+++ b/recoverylog/integration_test.go
@@ -218,7 +218,7 @@ func (s *RecoveryLogSuite) TestPlayThenCancel(c *gc.C) {
 	c.Check(r.player.FinishAtWriteHead(), gc.IsNil)
 
 	// Expect the local directory was deleted.
-	_, err = os.Stat(r.player.localDir)
+	_, err = os.Stat(r.player.dir)
 	c.Check(os.IsNotExist(err), gc.Equals, true)
 }
 

--- a/recoverylog/playback.go
+++ b/recoverylog/playback.go
@@ -2,6 +2,7 @@ package recoverylog
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -19,208 +19,386 @@ import (
 	"github.com/LiveRamp/gazette/topic"
 )
 
-const (
-	// Subdirectory into which Fnodes are played-back.
-	fnodeStagingDir = ".fnodes"
-	// Duration for which Player reads of the recovery log block.
-	blockInterval = 1 * time.Second
-)
-
-// Error returned by Player.Play() & MakeLive() upon Player.Cancel().
-var ErrPlaybackCancelled = fmt.Errorf("playback cancelled")
-
 type Player struct {
-	fsm *FSM
-	// Prefix added to recovered file paths.
-	localDir string
-	// Mapping of live Fnodes to local backing files.
-	backingFiles map[Fnode]*os.File
+	hints     FSMHints
+	localDir  string
+	tailingCh chan struct{}
+	handoffCh chan Author
+	exitCh    chan *FSM
 
-	// Signals to Play() service loop that Cancel() has been called.
-	cancelCh chan struct{}
-	// Signals to Play() service loop that MakeLive() has been called.
-	makeLiveCh chan struct{}
-	// Closed by Play() to signal to MakeLive() that Play() has exited.
-	playExitCh chan error
-	// Closed by Play() to signal that playback has reached the log head.
-	atHeadCh chan struct{}
+	// TODO(johnny): Plumb through a Context, and remove this.
+	cancelCh <-chan struct{}
 }
 
 // NewPlayer returns a new Player for recovering the log indicated by |hints|
-// into |localDir|. An error is returned if FSMHints are invalid.
+// into |dir|. An error is returned if |hints| are invalid.
 func NewPlayer(hints FSMHints, localDir string) (*Player, error) {
-	var fsm, err = NewFSM(hints)
-	if err != nil {
+	if _, err := NewFSM(hints); err != nil {
 		return nil, err
 	}
 
 	return &Player{
-		fsm:          fsm,
-		localDir:     localDir,
-		backingFiles: make(map[Fnode]*os.File),
-		cancelCh:     make(chan struct{}),
-		makeLiveCh:   make(chan struct{}),
-		// Buffered because Play() may exit before MakeLive() is called.
-		playExitCh: make(chan error, 1),
-		atHeadCh:   make(chan struct{}),
+		hints:     hints,
+		localDir:  localDir,
+		tailingCh: make(chan struct{}),
+		handoffCh: make(chan Author, 1),
+		exitCh:    make(chan *FSM),
 	}, nil
 }
 
-// Requests that Player finalize playback. An exit without error means Play()
-// has exited as well, after successfully restoring local file state to match
-// operations in the recovery-log through the current write head. The Player
-// FSM instance is returned, which can be used to construct Recorder for
-// recording further file state changes.
-func (p *Player) MakeLive() (*FSM, error) {
-	close(p.makeLiveCh)
-
-	// Wait for Play() to exit.
-	if err := <-p.playExitCh; err != nil {
-		return nil, err
-	}
-	return p.fsm, nil
+// PlayContext uses the prepared Player to play back the log. It returns on the
+// first encountered unrecoverable error, including context cancellation, or
+// upon a successful MakeLive or Handoff.
+func (p *Player) PlayContext(ctx context.Context, client journal.Client) error {
+	return playLog(ctx, p.hints, p.localDir, client, p.tailingCh, p.handoffCh, p.exitCh)
 }
 
-// IsAtLogHead returns true if playback has reached the WriteHead returned
-// by a Gazette Journal read. Note that Gazette reads are not transactional,
-// and this determination may be slightly stale.
-func (p *Player) IsAtLogHead() bool {
+// FinishAtWriteHead requests that playback complete upon reaching the current write
+// head. If Play returned without an error, FinishAtWriteHead will return its resulting
+// FSM (and will otherwise return nil). Only one invocation of FinishAtWriteHead or
+// InjectHandoff may be made of a Player instance.
+func (p *Player) FinishAtWriteHead() *FSM {
+	p.handoffCh <- 0
+	return <-p.exitCh
+}
+
+// InjectHandoff requests that playback complete upon injecting a no-op handoff of
+// the given |author| at the recoverylog head. If Play returned without an error,
+// InjectHandoff will return its resulting FSM (and will otherwise return nil).
+// Only one invocation of InjectHandoff or FinishAtWriteHead may be made of a
+// Player instance. |author| must be non-zero or InjectHandoff panics.
+func (p *Player) InjectHandoff(author Author) *FSM {
+	if author == 0 {
+		log.WithField("author", author).Panic("author must be non-zero")
+	}
+	p.handoffCh <- author
+	return <-p.exitCh
+}
+
+// IsTailing returns true if playback has reached the log write head and is
+// tailing new log operations as they arrive.
+func (p *Player) IsTailing() bool {
 	select {
-	case <-p.atHeadCh:
+	case <-p.tailingCh:
 		return true
 	default:
 		return false
 	}
 }
 
-// Requests that Player cancel playback and exit with an error.
-// Ignored if Play has already exited.
-func (p *Player) Cancel() { close(p.cancelCh) }
-
-// As an alternative to Cancel, SetCancelChan arranges for a subsequent Play
+// TODO(johnny): Plumb Context through Play, and remove.
+// Deprecated. SetCancelChan arranges for a subsequent Play
 // invocation to cancel playback upon |cancelCh| becoming select-able.
-func (p *Player) SetCancelChan(cancelCh chan struct{}) {
+func (p *Player) SetCancelChan(cancelCh <-chan struct{}) {
 	p.cancelCh = cancelCh
 }
 
-// Begins playing the prepared player. Returns on the first encountered
-// unrecoverable error, or upon a successful MakeLive().
+// Deprecated. Play using the prepared Player. Returns on the first encountered
+// unrecoverable error, or upon a successful MakeLive or Handoff.
 func (p *Player) Play(client journal.Client) error {
+	// Start an adapter to close the playLog Context on cancelCh being selectable.
+	// TODO(johnny): Remove after context is plumbed through Play.
+	var ctx, cancel = context.WithCancel(context.TODO())
+	if p.cancelCh != nil {
+		go func() {
+			<-p.cancelCh
+			cancel()
+		}()
+	}
+	return p.PlayContext(ctx, client)
+}
 
-	// Error checks in this function consistently use |err|. We defer sending
-	// |err| on return, to make it available for MakeLive as well.
-	var err error
-	defer func() {
-		if err != nil {
-			// Remove partial content from disk on playback failure or cancel.
-			p.cleanupAfterAbort()
+// playerReader is a cancel-able, buffered RetryReader which may be
+// asynchronously Peeked. This is a requirement for the playback loop, which
+// generally wants to use blocking reads while retaining an ability to cancel
+// pending read operations due to a signal to begin exiting.
+type playerReader struct {
+	rr          journal.RetryReader
+	br          *bufio.Reader      // Wraps |rr|.
+	cancelCtx   context.CancelFunc // Cancels the |rr| Context.
+	peekReqCh   chan<- struct{}    // Signals to begin a new Peek.
+	peekRespCh  <-chan error       // Signalled with the result of a Peek.
+	pendingPeek bool               // Indicates that a Peek is underway.
+}
+
+func newPlayerReader(ctx context.Context, mark journal.Mark, getter journal.Getter) *playerReader {
+	var pr = &playerReader{
+		rr: journal.RetryReader{
+			MarkedReader: journal.MarkedReader{Mark: mark},
+			Getter:       getter,
+		},
+	}
+	pr.rr.Context, pr.cancelCtx = context.WithCancel(ctx)
+	pr.br = bufio.NewReader(&pr.rr)
+
+	var reqCh = make(chan struct{}, 1)
+	var respCh = make(chan error, 1)
+
+	// Start a "peek pump", which allows us to request that a peek operation
+	// happen in the background to prime for reading the next operation.
+	go func(br *bufio.Reader, reqCh <-chan struct{}, respCh chan<- error) {
+		for range reqCh {
+			var _, err = br.Peek(1)
+			respCh <- err
 		}
-		p.playExitCh <- err
-	}()
 
-	if err = p.preparePlayback(); err != nil {
-		return err
+		if err := pr.rr.MarkedReader.Close(); err != nil {
+			log.WithField("err", err).Warn("error on close")
+		}
+		close(respCh)
+	}(pr.br, reqCh, respCh)
+
+	pr.peekReqCh = reqCh
+	pr.peekRespCh = respCh
+
+	return pr
+}
+
+func (pr *playerReader) peek() <-chan error {
+	if pr.pendingPeek == false {
+		pr.pendingPeek = true
+		pr.peekReqCh <- struct{}{}
+	}
+	return pr.peekRespCh
+}
+
+func (pr *playerReader) abort() {
+	pr.cancelCtx()
+	close(pr.peekReqCh)
+}
+
+// prepareRead ensures |pr| is prepared to read |nextOffset| in blocking mode |block|.
+// It may cancel |pr| and return a new *playerReader in its place.
+func prepareRead(ctx context.Context, pr *playerReader, nextOffset int64, block bool) *playerReader {
+	// Note that |pr.rr.MarkedReader| and |pr.br| cannot be concurrently accessed
+	// if |pr.pendingPeek| is true. The one exception is |MarkedReader.Mark.Journal|,
+	// which is never updated by a concurrent Read operation.
+
+	if block && !pr.rr.Blocking {
+		// We're switching to blocking mode. We can update the current reader to
+		// start blocking with its next read operation.
+		pr.rr.Blocking = true
+	} else if !block && pr.rr.Blocking {
+
+		if pr.pendingPeek || pr.rr.MarkedReader.ReadCloser != nil {
+			// As a blocking read is underway. We must begin a new, non-blocking
+			// read operation and cancel the older reader in the background.
+			var mark = journal.Mark{Journal: pr.rr.MarkedReader.Mark.Journal, Offset: nextOffset}
+
+			pr.abort()
+			pr = newPlayerReader(ctx, mark, pr.rr.Getter)
+		}
+		pr.rr.Blocking = false
 	}
 
-	// Note - here the fsm.LogMark is initialized to -1 on a new Player.
-	var rr = journal.NewRetryReader(p.fsm.LogMark, client)
-	defer rr.Close()
+	if !pr.pendingPeek && pr.rr.AdjustedMark(pr.br).Offset != nextOffset {
+		// Seek the RetryReader forward to the next hinted offset.
+		if _, err := pr.rr.Seek(nextOffset, io.SeekStart); err != nil {
+			panic(err) // The contract for RetryReader.Seek is that it never return an error.
+		}
+		pr.br.Reset(&pr.rr)
+	}
 
-	// Configure |rr| to periodically return EOF when no content is available.
-	rr.EOFTimeout = blockInterval
+	return pr
+}
 
-	var atHeadCh = p.atHeadCh // Retain on stack so it may be nil'd.
-	var br = bufio.NewReader(rr)
-	var makeLiveBarrier *journal.AsyncAppend
+type fnodeFileMap map[Fnode]*os.File
 
-	// Play until we're asked to make ourselves live, we've read through to the
-	// transactionally determined recoverylog WriteHead, and we time out
-	// waiting for new log content.
+// playerState models the recovery-log playback state machine.
+type playerState int
+
+const (
+	// Player is reading historical log content.
+	playerStateBackfill playerState = iota
+	// Player is tailing new log content as it is written.
+	playerStateTailing playerState = iota
+	// Player will exit after reading through the current log head.
+	playerStateExitingAtHead playerState = iota
+	// Player will inject a write barrier to attempt hand-off after reading through the log head.
+	playerStateHandoffInjectAtHead playerState = iota
+	// Player previously injected a write barrier, and is waiting to read it & determine if hand-off was successful.
+	playerStateHandoffReadBarrier playerState = iota
+	// Player has completed playback (terminal state).
+	playerStateComplete playerState = iota
+)
+
+// playLog applies |hints| to play the log (indicated by |hints|) into local
+// directory |dir|. It returns an encountered error (which aborts playback),
+// and otherwise blocks indefinitely until signalled by |handoffCh|. If signaled
+// with a zero-valued Author, playLog exits upon reaching the log head. Otherwise,
+// playLog exits upon injecting a properly sequenced no-op RecordedOp which encodes
+// the provided Author. If no error is returned, on exit |exitCh| is signaled with
+// the FSM recovered after playback.
+func playLog(ctx context.Context, hints FSMHints, dir string, client journal.Client,
+	tailingCh chan<- struct{}, handoffCh <-chan Author, exitCh chan<- *FSM) (err error) {
+
+	var state = playerStateBackfill
+	var fsm *FSM
+	var files = make(fnodeFileMap) // Live Fnodes backed by local files.
+	var handoff Author             // Author we will hand-off to on exit.
+
+	// Error checks in this function consistently use |err| prior to returning.
+	defer func() {
+		if err != nil {
+			cleanupAfterAbort(dir, files)
+		} else if state != playerStateComplete {
+			// |err| should be nil only on a successful playback completion.
+			log.WithField("state", state).Panic("unexpected state")
+		} else {
+			exitCh <- fsm
+		}
+		close(exitCh)
+	}()
+
+	if fsm, err = NewFSM(hints); err != nil {
+		return
+	} else if err = preparePlayback(dir); err != nil {
+		return
+	}
+
+	// Issue a write barrier to determine the transactional, current log head.
+	var asyncAppend *journal.AsyncAppend
+	if asyncAppend, err = client.Write(fsm.LogMark.Journal, nil); err != nil {
+		return
+	}
+	<-asyncAppend.Ready
+
+	// Offset we expect to have read through prior to exiting.
+	var writeHead = asyncAppend.WriteHead
+
+	var reader = newPlayerReader(ctx, fsm.LogMark, client)
+	defer func() { reader.abort() }() // Defer must be wrapped, as |reader| may change.
+
 	for {
 
-		select {
-		case <-p.makeLiveCh:
-			p.makeLiveCh = nil // Don't select again.
-
-			// Issue an empty write (a write barrier) to transactionally determine
-			// the minimum WriteHead we must read through.
-			if makeLiveBarrier, err = client.Write(p.fsm.LogMark.Journal, nil); err != nil {
-				return err
-			}
-			<-makeLiveBarrier.Ready
-
-			if err = makeLiveBarrier.Error; err != nil {
-				return err
-			}
-
-		case <-p.cancelCh:
-			err = ErrPlaybackCancelled
-			return err
-
-		default:
-			// Non-blocking.
+		if s := fsm.hintedSegments; len(s) != 0 && s[0].FirstOffset > fsm.LogMark.Offset {
+			// Use hinted offset to opportunistically skip through dead chunks of the log.
+			// Note that FSM is responsible for updating |hintedSegments| as they're applied.
+			fsm.LogMark.Offset = s[0].FirstOffset
+		} else if state == playerStateBackfill && fsm.LogMark.Offset == writeHead {
+			// We've completed back-fill and are now tailing the journal.
+			state = playerStateTailing
+			close(tailingCh)
+		} else if fsm.LogMark.Offset == -1 {
+			// In the absence of hinted segments, read from the current log head.
+			fsm.LogMark.Offset = writeHead
 		}
 
-		if s := p.fsm.hintedSegments; len(s) != 0 && s[0].FirstOffset > rr.AdjustedMark(br).Offset {
-			// Seek the RetryReader forward to the next hinted offset.
-			if _, err = rr.Seek(s[0].FirstOffset, os.SEEK_SET); err != nil {
-				return err
+		switch state {
+		case playerStateBackfill, playerStateTailing, playerStateHandoffReadBarrier:
+			// Always perform blocking reads from these states.
+			reader = prepareRead(ctx, reader, fsm.LogMark.Offset, true)
+		case playerStateExitingAtHead, playerStateHandoffInjectAtHead:
+			// If we believe we're at the log head and want to do something once we confirm it
+			// (exit, or inject a no-op), use non-blocking reads.
+			reader = prepareRead(ctx, reader, fsm.LogMark.Offset, fsm.LogMark.Offset < writeHead)
+		}
+
+		// Begin a read of the next operation. Wait for it to error or for the
+		// first byte to be ready, or to be signaled for hand-off.
+		select {
+		case err = <-reader.peek():
+			reader.pendingPeek = false
+			break
+
+		case handoff = <-handoffCh:
+			// We've been signaled to complete playback and exit when we're able.
+			switch state {
+			case playerStateBackfill, playerStateTailing:
+				if handoff == 0 {
+					state = playerStateExitingAtHead
+				} else {
+					state = playerStateHandoffInjectAtHead
+				}
+			default:
+				log.WithField("state", state).Panic("unexpected state")
 			}
-			br.Reset(rr)
 			continue
 		}
 
-		// Play the next operation. First Peek to ensure the next byte has been
-		// pre-fetched, which guarantees resolution of the absolute operation offset.
-		if _, err = br.Peek(1); err == nil {
-			p.fsm.LogMark = rr.AdjustedMark(br)
-			err = p.playOperation(br)
-		}
-
-		if err == io.EOF {
-			// EOF is returned only on operation message boundaries, and under
-			// RetryReader EOFTimeout semantics, only when a deadline read request
-			// completed with no content.
-			err = nil
-
-			if atHeadCh != nil {
-				close(atHeadCh)
-				atHeadCh = nil
+		if err == journal.ErrNotYetAvailable {
+			if fsm.LogMark.Offset < writeHead {
+				// This error is returned only by a non-blocking reader, and we should have used
+				// a non-blocking reader only if we were already at |writeHead|.
+				log.WithFields(log.Fields{"mark": fsm.LogMark, "writeHead": writeHead}).
+					Panic("unexpected ErrNotYetAvailable")
 			}
 
-			if makeLiveBarrier != nil {
-				var target = makeLiveBarrier.WriteHead
+			switch state {
+			case playerStateExitingAtHead:
+				state = playerStateComplete
+				err = makeLive(dir, fsm, files)
+				return
 
-				// A read WriteHead can increase that of |makeLiveBarrier|, but should
-				// not decrease it. Reads are not transactional and can be stale.
-				if rr.Result.WriteHead > target {
-					target = rr.Result.WriteHead
-				}
+			case playerStateHandoffInjectAtHead:
+				var noop = frameRecordedOp(RecordedOp{
+					SeqNo:    fsm.NextSeqNo,
+					Checksum: fsm.NextChecksum,
+					Author:   handoff,
+				}, nil)
 
-				if rr.Mark.Offset == target {
-					// Exit condition: we timed out waiting for content, we've been asked
-					// to make ourselves Live, and we've read to the target write head.
-					err = p.makeLive()
-					return err
+				if asyncAppend, err = client.Write(fsm.LogMark.Journal, noop); err != nil {
+					return
 				}
+				<-asyncAppend.Ready
+
+				// We next must read through the op we just wrote.
+				state, writeHead = playerStateHandoffReadBarrier, asyncAppend.WriteHead
+
+			default:
+				log.WithField("state", state).Panic("invalid state")
 			}
 		} else if err != nil {
-			// Any other error aborts playback.
-			return err
-		} else if atHeadCh != nil && rr.Result.WriteHead <= rr.Mark.Offset {
-			// Signal that playback has reached the approximate log head.
-			close(atHeadCh)
-			atHeadCh = nil
+			// Any other Peek error aborts playback.
+			return
+		}
+
+		// Gazette read operations can potentially update the log mark. Specifically,
+		// if the requested offset has been deleted from the log, the broker will
+		// return the next available offset.
+		fsm.LogMark = reader.rr.AdjustedMark(reader.br)
+
+		if reader.rr.LastResult.WriteHead > writeHead {
+			writeHead = reader.rr.LastResult.WriteHead
+		}
+
+		// Parse and apply the operation. Track the operation author, and whether it
+		// was correctly sequenced by the FSM (or otherwise, was ignored).
+		var opAuthor Author
+		var opApplied bool
+
+		if opAuthor, opApplied, err = playOperation(reader.br, dir, fsm, files); err != nil {
+			return
+		}
+
+		// Update again to reflect the next operation offset we intend to apply.
+		fsm.LogMark = reader.rr.AdjustedMark(reader.br)
+
+		if handoff != 0 && opAuthor == handoff {
+			if state != playerStateHandoffReadBarrier {
+				log.WithField("state", state).Panic("unexpected state")
+			}
+
+			if opApplied {
+				// We successfully sequenced a no-op into the log, taking control of
+				// the log from a current recorder (if one exists).
+				state = playerStateComplete
+				err = makeLive(dir, fsm, files)
+				return
+			}
+
+			// We lost the race to inject our write operation, and must try again.
+			state = playerStateHandoffInjectAtHead
 		}
 	}
 }
 
-func (p *Player) preparePlayback() error {
-	// File nodes are staged into a directory within |localDir| during playback.
-	var fileNodesDir = filepath.Join(p.localDir, fnodeStagingDir)
+func preparePlayback(dir string) error {
+	// File nodes are staged into a directory within |dir| during playback.
+	var fileNodesDir = filepath.Join(dir, fnodeStagingDir)
 
-	// Remove all prior content under |p.localDir|.
-	if err := os.RemoveAll(p.localDir); err != nil {
+	// Remove all prior content under |dir|.
+	if err := os.RemoveAll(dir); err != nil {
 		return err
 	} else if err := os.MkdirAll(fileNodesDir, 0777); err != nil {
 		return err
@@ -228,107 +406,117 @@ func (p *Player) preparePlayback() error {
 	return nil
 }
 
-func (p *Player) cleanupAfterAbort() {
-	for _, fnode := range p.backingFiles {
+func cleanupAfterAbort(dir string, files fnodeFileMap) {
+	for _, fnode := range files {
 		if err := fnode.Close(); err != nil {
 			log.WithField("err", err).Warn("closing fnode after abort")
 		}
 	}
-	if err := os.RemoveAll(p.localDir); err != nil {
-		log.WithField("err", err).Warn("removing localDir after abort")
+	if err := os.RemoveAll(dir); err != nil {
+		log.WithField("err", err).Warn("removing local directory after abort")
 	}
 }
 
-func (p *Player) playOperation(br *bufio.Reader) error {
-	var b, err = topic.FixedFraming.Unpack(br)
+// playOperation reads and applies a single RecordedOp from |br|. It returns
+// the operation |author| and whether it was successfully |applied| to the FSM,
+// and any other encountered playback |err|.
+func playOperation(br *bufio.Reader, dir string, fsm *FSM, files fnodeFileMap) (author Author, applied bool, err error) {
+	var b []byte
 	var op RecordedOp
 
-	if err != nil {
-		return err
+	if b, err = topic.FixedFraming.Unpack(br); err != nil {
+		return
 	} else if err = topic.FixedFraming.Unmarshal(b, &op); err == topic.ErrDesyncDetected {
 		// Garbage frame. Treat as no-op operation, allowing playback to continue.
-		log.WithField("mark", p.fsm.LogMark).Warn("detected de-synchronization")
-		return nil
+		err = nil
+		log.WithField("mark", fsm.LogMark).Warn("detected de-synchronization")
+		return
 	} else if err != nil {
-		return err
+		return
 	}
 
+	author = op.Author
+
 	// Run the operation through the FSM to verify validity.
-	if fsmErr := p.fsm.Apply(&op, b[topic.FixedFrameHeaderLength:]); fsmErr != nil {
+	if fsmErr := fsm.Apply(&op, b[topic.FixedFrameHeaderLength:]); fsmErr != nil {
 		// Log but otherwise ignore FSM errors: the Player is still in a consistent
 		// state, and we may make further progress later in the log.
 		if fsmErr == ErrFnodeNotTracked {
 			// Fnode is deleted later in the log, and is no longer hinted.
-		} else if fsmErr == ErrWrongSeqNo && op.SeqNo < p.fsm.NextSeqNo {
+		} else if fsmErr == ErrWrongSeqNo && op.SeqNo < fsm.NextSeqNo {
 			// |op| is prior to the next hinted SeqNo. We may have started reading
 			// from a lower-bound offset, or it may be a duplicated write.
 		} else {
-			log.WithFields(log.Fields{"op": op, "err": fsmErr}).Warn("playback FSM error")
+			log.WithFields(log.Fields{"mark": fsm.LogMark, "op": op, "err": fsmErr}).Warn("playback FSM error")
 		}
 
 		// For bytestream consistency Write ops must still skip |op.Length| bytes.
 		if op.Write != nil {
-			if err := copyFixed(ioutil.Discard, br, op.Write.Length); err != nil {
-				return err
-			}
+			err = copyFixed(ioutil.Discard, br, op.Write.Length)
 		}
-		return nil
+		return
 	}
+
+	applied = true
 
 	// The operation is valid. Apply local playback actions.
 	if op.Create != nil {
-		return p.create(Fnode(op.SeqNo))
+		err = create(dir, Fnode(op.SeqNo), files)
 	} else if op.Unlink != nil {
-		return p.unlink(op.Unlink.Fnode)
+		err = unlink(dir, op.Unlink.Fnode, fsm, files)
 	} else if op.Write != nil {
 		metrics.RecoveryLogRecoveredBytesTotal.Add(float64(op.Write.Length))
-		return p.write(op.Write, br)
+		err = write(op.Write, br, files)
 	}
-	return nil
+
+	return
 }
 
-func (p *Player) stagedPath(fnode Fnode) string {
-	fname := strconv.FormatInt(int64(fnode), 10)
-	return filepath.Join(p.localDir, fnodeStagingDir, fname)
+func stagedPath(dir string, fnode Fnode) string {
+	var fname = strconv.FormatInt(int64(fnode), 10)
+	return filepath.Join(dir, fnodeStagingDir, fname)
 }
 
-func (p *Player) create(fnode Fnode) error {
-	backingFile, err := os.OpenFile(p.stagedPath(fnode),
+func create(dir string, fnode Fnode, files fnodeFileMap) error {
+	var file, err = os.OpenFile(stagedPath(dir, fnode),
 		os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666) // Expect file to not exist.
+
 	if err == nil {
-		p.backingFiles[fnode] = backingFile
+		files[fnode] = file
 	}
 	return err
 }
 
-func (p *Player) unlink(fnode Fnode) error {
-	if _, isLive := p.fsm.LiveNodes[fnode]; isLive {
+func unlink(dir string, fnode Fnode, fsm *FSM, files fnodeFileMap) error {
+	if _, isLive := fsm.LiveNodes[fnode]; isLive {
 		// Live links remain for |fnode|. Take no action.
 		return nil
 	}
-	backingFile := p.backingFiles[fnode]
+	var file = files[fnode]
 
 	// Close and remove the local backing file.
-	if err := backingFile.Close(); err != nil {
+	if err := file.Close(); err != nil {
 		return err
-	} else if err = os.Remove(p.stagedPath(fnode)); err != nil {
+	} else if err = os.Remove(stagedPath(dir, fnode)); err != nil {
 		return err
 	}
-	delete(p.backingFiles, fnode)
+	delete(files, fnode)
 	return nil
 }
 
-func (p *Player) write(op *RecordedOp_Write, r io.Reader) error {
-	var backingFile = p.backingFiles[Fnode(op.Fnode)]
+func write(op *RecordedOp_Write, r io.Reader, files fnodeFileMap) error {
+	var file = files[Fnode(op.Fnode)]
 
 	// Seek to the indicated offset.
-	if _, err := backingFile.Seek(op.Offset, 0); err != nil {
+	if _, err := file.Seek(op.Offset, 0); err != nil {
 		return err
 	}
-	return copyFixed(backingFile, r, op.Length)
+	return copyFixed(file, r, op.Length)
 }
 
-// Copies exactly |length| bytes from |r| to |w| using temporary buffer |b|.
+// copyFixed is like io.CopyN, but treats an EOF prior to |length| as an
+// ErrUnexpectedEOF. It also uses a |copyBuffers| pool to avoid a buffer
+// allocation.
 func copyFixed(w io.Writer, r io.Reader, length int64) error {
 	var b = copyBuffers.Get().(*[]byte)
 	var n, err = io.CopyBuffer(w, io.LimitReader(r, length), *b)
@@ -341,44 +529,47 @@ func copyFixed(w io.Writer, r io.Reader, length int64) error {
 	return err
 }
 
-func (p *Player) makeLive() error {
-	if p.fsm.HasHints() {
-		return fmt.Errorf("FSM has remaining unused hints: %+v", p.fsm)
+// makeLive links staged Fnode |files| into each of their hard link locations
+// indicated by |fsm| under |dir|, and creates any property files of |fsm|.
+// |files| must exactly match live nodes of |fsm| or makeLive panics.
+func makeLive(dir string, fsm *FSM, files fnodeFileMap) error {
+	if fsm.HasHints() {
+		return fmt.Errorf("FSM has remaining unused hints: %+v", fsm)
 	}
-	for fnode, liveNode := range p.fsm.LiveNodes {
-		backingFile := p.backingFiles[fnode]
-		delete(p.backingFiles, fnode)
+	for fnode, liveNode := range fsm.LiveNodes {
+		var file = files[fnode]
+		delete(files, fnode)
 
 		// Link backing-file into target paths.
 		for link := range liveNode.Links {
-			targetPath := filepath.Join(p.localDir, link)
+			targetPath := filepath.Join(dir, link)
 
 			if err := os.MkdirAll(filepath.Dir(targetPath), 0777); err != nil {
 				return err
-			} else if err = os.Link(p.stagedPath(fnode), targetPath); err != nil {
+			} else if err = os.Link(stagedPath(dir, fnode), targetPath); err != nil {
 				return err
 			}
 			log.WithFields(log.Fields{"fnode": fnode, "target": targetPath}).Info("linked file")
 		}
 		// Close and removed the staged file.
-		if err := backingFile.Close(); err != nil {
+		if err := file.Close(); err != nil {
 			return err
-		} else if err = os.Remove(p.stagedPath(fnode)); err != nil {
+		} else if err = os.Remove(stagedPath(dir, fnode)); err != nil {
 			return err
 		}
 	}
-	if len(p.backingFiles) != 0 {
+	if len(files) != 0 {
 		// Invariant: |FSM.LiveNodes| should fully describe all backing files.
-		log.WithField("files", p.backingFiles).Panic("backing files not in FSM")
+		log.WithField("files", files).Panic("backing files not in FSM")
 	}
 	// Remove staging directory.
-	if err := os.Remove(filepath.Join(p.localDir, fnodeStagingDir)); err != nil {
+	if err := os.Remove(filepath.Join(dir, fnodeStagingDir)); err != nil {
 		return err
 	}
 
 	// Write property files.
-	for path, content := range p.fsm.Properties {
-		targetPath := filepath.Join(p.localDir, path)
+	for path, content := range fsm.Properties {
+		var targetPath = filepath.Join(dir, path)
 
 		// Write |content| to |targetPath|. Expect it to not exist.
 		if err := os.MkdirAll(filepath.Dir(targetPath), 0777); err != nil {
@@ -394,6 +585,9 @@ func (p *Player) makeLive() error {
 	}
 	return nil
 }
+
+// Subdirectory into which Fnodes are played-back.
+const fnodeStagingDir = ".fnodes"
 
 var (
 	copyBuffers = sync.Pool{

--- a/recoverylog/recorded_op.proto
+++ b/recoverylog/recorded_op.proto
@@ -29,6 +29,24 @@ message RecordedOp {
 
   // RecordedOp is a union-type over the remaining fields.
 
+  // A no-op may also be represented as a RecordedOp with no fields set. This
+  // is principally useful for issuing transactional write-barriers at log
+  // handoff. Eg, given a log Player which desires to be the log Recorder:
+  //
+  //   1) The Player will read all available log content, and then inject
+  //      what it understands to be a correctly sequenced no-op with
+  //      its unique author ID. Note that this injected operation may well
+  //      lose a write race with another Recorder, resulting in its being
+  //      mis-sequenced and ignored by other readers.
+  //
+  //   2) It will continue to read the log until its no-op is read.
+  //      If the operation is mis-sequenced, it will restart from step 1.
+  //
+  //   3) If the no-op is sequenced correctly, it will terminate playback
+  //      immediately after the no-op and transition to recording new log
+  //      operations. Any following, raced writes must be mis-sequenced,
+  //      having lost the write race, and will be ignored by other readers.
+
   // Creates a new file-node with id |seq_no|, initially linked to |path|.
   message Create {
     option (gogoproto.goproto_unrecognized) = false;


### PR DESCRIPTION
Formerly, `recoverylog` playback used behavior of waiting for a timeout
during which no new content became available from the broker. On
reaching that timeout, playback was assumed to be complete and the
consumer would switch from replicating to recording new state changes.

This invited race conditions, where a prior recorder which was delayed
in flushing final writes to the log would race with the new recorder.
Ordinarily FSMHints are sufficient to resolve the forked log history,
but this is a problem for other warm-standby replicas which are
live-tailing the log: depending on which raced write wins, they may
follow a fork of log history which is shutting down, and ignored the new
recorder entirely.

Fix this by changing player behavior to allow for injecting "hand-off"
noop RecordedOps, which serve as write-barriers that effectively give
control of the log to a new recorder in the eyes of any other tailers of
the log. Timeout-based polling is removed entirely.

This has a number of spill-over implications. Playback must now use a
mix of blocking and non-blocking reads, and `RetryReader` is refactored
to support this behavior. Use of Context is introduced to signal
deadlines and cancellations, and the server-side blocking duration
mechanic is deprecated (in favor of client-side cancellation). The
Author ID must be shared between the `Player` and `Recorder`, motivating
a refactor of `consumer/master.go`.

Also, switch ShardPreInitHook => ShardPostInitHook. In usages such as
ShardIndex, the expectation is the Shard is fully initialized, making a
Post-hook appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/4)
<!-- Reviewable:end -->
