### PR TITLE
instrument APIs with context and tracing

### DIFF
--- a/gazette/replicate_api.go
+++ b/gazette/replicate_api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/trace"
 
 	"github.com/LiveRamp/gazette/journal"
 	"github.com/LiveRamp/gazette/metrics"
@@ -31,15 +32,24 @@ func (h *ReplicateAPI) Register(router *mux.Router) {
 }
 
 func (h *ReplicateAPI) Replicate(w http.ResponseWriter, r *http.Request) {
+	r = maybeTrace(r, "ReplicateAPI.Replicate")
+	defer finishTrace(r)
+
 	var schema struct {
 		WriteHead  int64
 		RouteToken string
 		NewSpool   bool
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	} else if err = h.decoder.Decode(&schema, r.Form); err != nil {
+	var err error
+
+	if err = r.ParseForm(); err == nil {
+		err = h.decoder.Decode(&schema, r.Form)
+	}
+	if err != nil {
+		if tr, ok := trace.FromContext(r.Context()); ok {
+			tr.LazyPrintf("parsing request: %v", err)
+			tr.SetError()
+		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -50,38 +60,47 @@ func (h *ReplicateAPI) Replicate(w http.ResponseWriter, r *http.Request) {
 			RouteToken: journal.RouteToken(schema.RouteToken),
 			WriteHead:  schema.WriteHead,
 			NewSpool:   schema.NewSpool,
+			Context:    r.Context(),
 		},
 		Result: make(chan journal.ReplicateResult, 1),
 	}
 
 	h.handler.Replicate(op)
-	result := <-op.Result
+	var result = <-op.Result
 
 	if result.Error != nil {
 		if result.ErrorWriteHead != 0 {
-			w.Header().Add(WriteHeadHeader,
-				strconv.FormatInt(result.ErrorWriteHead, 16))
+			w.Header().Add(WriteHeadHeader, strconv.FormatInt(result.ErrorWriteHead, 16))
 		}
 		http.Error(w, result.Error.Error(), journal.StatusCodeForError(result.Error))
 		return
 	}
-	var err error
-	var commitDelta int64
+	var n, commitDelta int64
 
-	if _, err = io.Copy(result.Writer, r.Body); err != nil {
+	if n, err = io.Copy(result.Writer, r.Body); err != nil {
 		result.Writer.Commit(0) // Abort.
 	} else if commitDelta, err = strconv.ParseInt(
 		r.Trailer.Get(CommitDeltaHeader), 16, 64); err != nil {
 		result.Writer.Commit(0) // Abort.
-	} else if err = result.Writer.Commit(commitDelta); err != nil {
-		// Abort.
 	} else {
-		w.WriteHeader(http.StatusNoContent) // Success.
+		err = result.Writer.Commit(commitDelta)
+	}
+
+	if tr, ok := trace.FromContext(r.Context()); ok {
+		tr.LazyPrintf("copied %d bytes / commit %d", n, commitDelta)
+
+		if err != nil {
+			tr.LazyPrintf("commit error: %v", err)
+			tr.SetError()
+		}
+	}
+
+	if err != nil {
+		log.WithField("err", err).Warn("failed to commit transaction")
+		metrics.FailedCommitsTotal.Inc()
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	log.WithField("err", err).Warn("failed to commit transaction")
-	metrics.FailedCommitsTotal.Inc()
-	http.Error(w, err.Error(), http.StatusInternalServerError)
-	return
+	w.WriteHeader(http.StatusNoContent) // Success.
 }

--- a/gazette/router_test.go
+++ b/gazette/router_test.go
@@ -1,6 +1,7 @@
 package gazette
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -19,8 +20,11 @@ func (s *RouterSuite) TestReadConditions(c *gc.C) {
 
 	var resultCh = make(chan journal.ReadResult, 1)
 	var op = journal.ReadOp{
-		ReadArgs: journal.ReadArgs{Journal: "foo/bar"},
-		Result:   resultCh,
+		ReadArgs: journal.ReadArgs{
+			Journal: "foo/bar",
+			Context: context.Background(),
+		},
+		Result: resultCh,
 	}
 
 	// Journal is not known.
@@ -65,8 +69,11 @@ func (s *RouterSuite) TestAppendConditions(c *gc.C) {
 
 	var resultCh = make(chan journal.AppendResult, 1)
 	var op = journal.AppendOp{
-		AppendArgs: journal.AppendArgs{Journal: "foo/bar"},
-		Result:     resultCh,
+		AppendArgs: journal.AppendArgs{
+			Journal: "foo/bar",
+			Context: context.Background(),
+		},
+		Result: resultCh,
 	}
 
 	// Journal is not known.
@@ -135,8 +142,11 @@ func (s *RouterSuite) TestReplicateConditions(c *gc.C) {
 
 	var resultCh = make(chan journal.ReplicateResult, 1)
 	var op = journal.ReplicateOp{
-		ReplicateArgs: journal.ReplicateArgs{Journal: "foo/bar"},
-		Result:        resultCh,
+		ReplicateArgs: journal.ReplicateArgs{
+			Journal: "foo/bar",
+			Context: context.Background(),
+		},
+		Result: resultCh,
 	}
 
 	router.Replicate(op)

--- a/gazette/tracing.go
+++ b/gazette/tracing.go
@@ -1,0 +1,25 @@
+package gazette
+
+import (
+	"net/http"
+
+	"golang.org/x/net/trace"
+)
+
+// maybeTrace instruments specific Requests for tracing. At present, all
+// requests are traced. In the future, we may want to flag this, or
+// selectively trace certain journals, or enable with URL query arguments,
+// or some combination of these.
+func maybeTrace(r *http.Request, api string) *http.Request {
+	var tr = trace.New(api, r.URL.Path)
+	tr.LazyPrintf("RemoteAddr: %s", r.RemoteAddr)
+	return r.WithContext(trace.NewContext(r.Context(), tr))
+}
+
+// finishTrace finishes a running trace of the request, if it exists.
+// It is intended to be defered immediately after a `maybeTrace`.
+func finishTrace(r *http.Request) {
+	if tr, ok := trace.FromContext(r.Context()); ok {
+		tr.Finish()
+	}
+}

--- a/gazette/write_api.go
+++ b/gazette/write_api.go
@@ -22,10 +22,14 @@ func (h *WriteAPI) Register(router *mux.Router) {
 }
 
 func (h *WriteAPI) Write(w http.ResponseWriter, r *http.Request) {
+	r = maybeTrace(r, "WriteAPI.Write")
+	defer finishTrace(r)
+
 	var op = journal.AppendOp{
 		AppendArgs: journal.AppendArgs{
 			Journal: journal.Name(r.URL.Path[1:]),
 			Content: r.Body,
+			Context: r.Context(),
 		},
 		Result: make(chan journal.AppendResult, 1),
 	}

--- a/gazetted/main.go
+++ b/gazetted/main.go
@@ -114,6 +114,7 @@ func main() {
 					AppendArgs: journal.AppendArgs{
 						Journal: name,
 						Content: &emptyBuffer,
+						Context: context.Background(),
 					},
 					Result: resultCh,
 				})

--- a/journal/broker_test.go
+++ b/journal/broker_test.go
@@ -2,6 +2,7 @@ package journal
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing/iotest"
 
@@ -26,12 +27,14 @@ func (s *BrokerSuite) SetUpTest(c *gc.C) {
 	s.broker.Append(AppendOp{
 		AppendArgs: AppendArgs{
 			Content: bytes.NewBufferString("write one "),
+			Context: context.Background(),
 		},
 		Result: s.appendResults,
 	})
 	s.broker.Append(AppendOp{
 		AppendArgs: AppendArgs{
 			Content: bytes.NewBufferString("write two "),
+			Context: context.Background(),
 		},
 		Result: s.appendResults,
 	})
@@ -163,6 +166,7 @@ func (s *BrokerSuite) TestBrokenReadHandling(c *gc.C) {
 		AppendArgs: AppendArgs{
 			Content: iotest.OneByteReader(
 				iotest.TimeoutReader(bytes.NewBufferString("!!!!"))),
+			Context: context.Background(),
 		},
 		Result: s.appendResults,
 	})
@@ -170,6 +174,7 @@ func (s *BrokerSuite) TestBrokenReadHandling(c *gc.C) {
 	s.broker.Append(AppendOp{
 		AppendArgs: AppendArgs{
 			Content: bytes.NewBufferString(" separate"),
+			Context: context.Background(),
 		},
 		Result: s.appendResults,
 	})

--- a/journal/protocol.go
+++ b/journal/protocol.go
@@ -47,6 +47,17 @@ type ReplicateArgs struct {
 	RouteToken
 	// Flags whether replicas should begin a new spool for this transaction.
 	NewSpool bool
+	// Context which may trace, cancel or supply a deadline for the operation.
+	Context context.Context
+}
+
+func (a ReplicateArgs) String() string {
+	return fmt.Sprintf("%+v", struct {
+		Journal   Name
+		WriteHead int64
+		RouteToken
+		NewSpool bool
+	}{a.Journal, a.WriteHead, a.RouteToken, a.NewSpool})
 }
 
 type ReplicateResult struct {
@@ -56,6 +67,13 @@ type ReplicateResult struct {
 	ErrorWriteHead int64
 	// Set iff |Error| is nil.
 	Writer WriteCommitter
+}
+
+func (a ReplicateResult) String() string {
+	return fmt.Sprintf("%+v", struct {
+		Error          error
+		ErrorWriteHead int64
+	}{a.Error, a.ErrorWriteHead})
 }
 
 type ReplicateOp struct {
@@ -77,13 +95,22 @@ type ReadArgs struct {
 	// Whether the operation should block until content becomes available.
 	// ErrNotYetAvailable is returned if a non-blocking read has no ready content.
 	Blocking bool
-	// Context which may cancel or supply a deadline for the operation.
+	// Context which may trace, cancel or supply a deadline for the operation.
 	Context context.Context
 
 	// Deprecated: Server-side support for deadlines will be removed. Use
 	// context.WithDeadline instead.
 	// The time at which blocking will expire
 	Deadline time.Time
+}
+
+func (a ReadArgs) String() string {
+	return fmt.Sprintf("%+v", struct {
+		Journal  Name
+		Offset   int64
+		Blocking bool
+		Deadline time.Time
+	}{a.Journal, a.Offset, a.Blocking, a.Deadline})
 }
 
 type ReadResult struct {
@@ -96,6 +123,18 @@ type ReadResult struct {
 	RouteToken
 	// Result fragment, set iff |Error| is nil.
 	Fragment Fragment
+}
+
+func (a ReadResult) String() string {
+	return fmt.Sprintf("%+v", struct {
+		Error     error
+		Offset    int64
+		WriteHead int64
+		RouteToken
+		Fragment string
+		IsLocal  bool
+	}{a.Error, a.Offset, a.WriteHead, a.RouteToken,
+		a.Fragment.ContentPath(), a.Fragment.File != nil})
 }
 
 type ReadOp struct {
@@ -111,6 +150,14 @@ type AppendArgs struct {
 	// until io.EOF, and abort the append (without committing any content)
 	// if any other error is returned by |Content.Read()|.
 	Content io.Reader
+	// Context which may trace, cancel or supply a deadline for the operation.
+	Context context.Context
+}
+
+func (a AppendArgs) String() string {
+	return fmt.Sprintf("%+v", struct {
+		Journal Name
+	}{a.Journal})
 }
 
 type AppendResult struct {
@@ -120,6 +167,14 @@ type AppendResult struct {
 	WriteHead int64
 	// RouteToken of the Journal. Set on ErrNotBroker.
 	RouteToken
+}
+
+func (a AppendResult) String() string {
+	return fmt.Sprintf("%+v", struct {
+		Error     error
+		WriteHead int64
+		RouteToken
+	}{a.Error, a.WriteHead, a.RouteToken})
 }
 
 type AppendOp struct {

--- a/journal/tail.go
+++ b/journal/tail.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/trace"
 )
 
 const (
@@ -152,6 +153,9 @@ func (t *Tail) onRead(op ReadOp) {
 					t.deadline.next = op.Deadline
 					t.deadline.timer.Reset(op.Deadline.Sub(time.Now()))
 				}
+			}
+			if tr, ok := trace.FromContext(op.Context); ok {
+				tr.LazyPrintf("Tail.onRead: blocked read")
 			}
 			t.blockedReads = append(t.blockedReads, op)
 		} else {


### PR DESCRIPTION
Each of the read, append, and replication APIs and operations are wired
with contexts and instrumentation for an associated optional trace.

PUB-4116

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/8)
<!-- Reviewable:end -->
