### PR TITLE
Revert "Generate mocks via go:generate directives (#7)"

### DIFF
--- a/build/Dockerfile.gazette-build
+++ b/build/Dockerfile.gazette-build
@@ -41,7 +41,22 @@ RUN base=github.com/LiveRamp/gazette ; \
       protoc -I src/ -I src/$base/vendor/ --plugin=/go/bin/protoc-gen-gogo \
         --gogo_out=plugins=grpc:src/ $tgt ; \
     done ; \
-    go generate "$base/..." ;
+    \
+    for tgt in \
+      $base/consensus/Allocator \
+      $base/consensus/KeysAPI \
+      $base/consensus/Watcher \
+      $base/consumer/ConsumerServer \
+      $base/consumer/Shard \
+      $base/gazette/httpClient \
+      $base/journal/Doer \
+      $base/journal/FragmentFile \
+      $base/journal/Getter \
+      $base/journal/Header \
+      $base/journal/Writer \
+    ; do \
+      mockery -inpkg -name $(basename ${tgt}) -dir /go/src/$(dirname ${tgt}) ; \
+    done ;
 
 # Copy compiled targets.
 # TODO(johnny): Move all executable targets under gazette/cmd.

--- a/consensus/allocator.go
+++ b/consensus/allocator.go
@@ -13,8 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//go:generate mockery -inpkg -name=Allocator
-
 const (
 	MemberPrefix = "members" // Directory root for member announcements.
 	ItemsPrefix  = "items"   // Directory root for allocated items.

--- a/consensus/tree_ops.go
+++ b/consensus/tree_ops.go
@@ -10,9 +10,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-//go:generate mockery -inpkg -name=KeysAPI
-//go:generate mockery -inpkg -name=Watcher
-
 var (
 	etcdUpsertOps = map[string]struct{}{
 		store.CompareAndSwap: {},

--- a/consumer/interfaces.go
+++ b/consumer/interfaces.go
@@ -6,8 +6,6 @@ import (
 	"github.com/LiveRamp/gazette/topic"
 )
 
-//go:generate mockery -inpkg -name=Shard
-
 // ShardID uniquely identifies a specific Shard. A ShardID must be consistent
 // across processes for the entire duration of the Consumer lifetime.
 type ShardID string

--- a/consumer/test_support.go
+++ b/consumer/test_support.go
@@ -14,11 +14,6 @@ import (
 	"github.com/LiveRamp/gazette/topic"
 )
 
-// ConsumerServer is generated from service.proto. This go:generate directive
-// is placed here to avoid relying on the protobuf compiler to propagate it to
-// generated Go source.
-//go:generate mockery -inpkg -name=ConsumerServer
-
 // Test support function. Initializes all shards of |runner| to empty database
 // which begin consumption from the current write-head of each topic journal.
 func ResetShardsToJournalHeads(runner *Runner) error {

--- a/gazette/client.go
+++ b/gazette/client.go
@@ -23,8 +23,6 @@ import (
 	"github.com/LiveRamp/gazette/metrics"
 )
 
-//go:generate mockery -inpkg -name=httpClient
-
 const (
 	// By default, all client operations are applied against the default
 	// endpoint. However, the client will cache the last |kClientRouteCacheSize|

--- a/journal/interfaces.go
+++ b/journal/interfaces.go
@@ -6,12 +6,6 @@ import (
 	"net/url"
 )
 
-//go:generate mockery -inpkg -name=Doer
-//go:generate mockery -inpkg -name=FragmentFile
-//go:generate mockery -inpkg -name=Getter
-//go:generate mockery -inpkg -name=Header
-//go:generate mockery -inpkg -name=Writer
-
 // A typed journal name. By convention, journals are named using a forward-
 // slash notation which captures their hierarchical relationships into
 // organizations, topics and partitions. For example, a complete Name might be:


### PR DESCRIPTION
This reverts commit 4539428c518ec50ca3aa86a4e49c6b997002cf45.

We would like to have more control over the build process than
go:generate is able to offer.

Jira: PUB-4488

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/9)
<!-- Reviewable:end -->
