### PR TITLE
Add check for os.ErrNotExist in isDir func

### DIFF
--- a/cloudstore/sftp_fs.go
+++ b/cloudstore/sftp_fs.go
@@ -477,6 +477,8 @@ func isSSHError(err error, sshCode uint32) bool {
 func (s *sftpFs) isDir(path string) (bool, error) {
 	if stat, err := s.client.Lstat(path); err == nil {
 		return stat.IsDir(), nil
+	} else if err == os.ErrNotExist {
+		return false, nil
 	} else if isSSHError(err, SSHErrFileNotFound) {
 		return false, nil
 	} else {

--- a/cloudstore/sftp_fs.go
+++ b/cloudstore/sftp_fs.go
@@ -477,9 +477,7 @@ func isSSHError(err error, sshCode uint32) bool {
 func (s *sftpFs) isDir(path string) (bool, error) {
 	if stat, err := s.client.Lstat(path); err == nil {
 		return stat.IsDir(), nil
-	} else if err == os.ErrNotExist {
-		return false, nil
-	} else if isSSHError(err, SSHErrFileNotFound) {
+	} else if err == os.ErrNotExist || isSSHError(err, SSHErrFileNotFound) {
 		return false, nil
 	} else {
 		return false, err


### PR DESCRIPTION
As written, this function will fail on newer versions of pkg/sftp, because they are now normalizing the errors from SSH errors to OS ones. This change accounts for that and restores isDir to working order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/12)
<!-- Reviewable:end -->
