### PR TITLE
Avoid racing when generating multiple mocks in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-mock_*.go
 mocks/
 *.pb.go
 vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 mock_*.go
+mocks/
 *.pb.go
 vendor

--- a/build/Dockerfile.gazette-build
+++ b/build/Dockerfile.gazette-build
@@ -35,7 +35,7 @@ COPY topic /go/src/github.com/LiveRamp/gazette/topic
 RUN base=github.com/LiveRamp/gazette ; \
     set -x ; \
     for tgt in \
-      $base/consumer/service.proto \
+      $base/consumer/service/service.proto \
       $base/recoverylog/recorded_op.proto \
     ; do \
       protoc -I src/ -I src/$base/vendor/ --plugin=/go/bin/protoc-gen-gogo \

--- a/cloudstore/common_test.go
+++ b/cloudstore/common_test.go
@@ -5,15 +5,15 @@ import (
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/LiveRamp/gazette/consensus"
+	"github.com/LiveRamp/gazette/consensus/mocks"
 )
 
 type CommonSuite struct {
-	keys *consensus.MockKeysAPI
+	keys *mocks.KeysAPI
 }
 
 func (s *CommonSuite) SetUpSuite(c *gc.C) {
-	s.keys = new(consensus.MockKeysAPI)
+	s.keys = new(mocks.KeysAPI)
 
 	var awsEndpoint = &etcd.Response{
 		Node: &etcd.Node{Value: testAWSEndpoint},

--- a/cmd/run-consumer/main.go
+++ b/cmd/run-consumer/main.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/LiveRamp/gazette/consumer"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/gazette"
 )
 
@@ -41,10 +42,10 @@ func main() {
 	}
 	flag.Parse() // Parse again to initialize any plugin flags.
 
-	var instance consumer.Consumer
+	var instance service.Consumer
 	if i, err := module.Lookup("Consumer"); err != nil {
 		log.WithField("err", err).Fatal("failed to lookup Consumer symbol")
-	} else if c, ok := i.(*consumer.Consumer); !ok {
+	} else if c, ok := i.(*service.Consumer); !ok {
 		log.WithField("instance", i).Fatalf("symbol `Consumer` is not a consumer.Consumer: %#v", i)
 	} else {
 		instance = *c

--- a/consensus/allocator.go
+++ b/consensus/allocator.go
@@ -11,6 +11,8 @@ import (
 
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/LiveRamp/gazette/consensus/allocator"
 )
 
 //go:generate mockery -inpkg -name=Allocator
@@ -29,38 +31,6 @@ const (
 
 var ErrAllocatorInstanceExists = errors.New("Allocator member key exists")
 
-// Allocator is an interface which performs distributed allocation of items.
-type Allocator interface {
-	KeysAPI() etcd.KeysAPI
-	// Etcd path which roots shared state for this Context.
-	PathRoot() string
-	// A key uniquely identifying this Allocator within shared state.
-	InstanceKey() string
-	// The required number of replicas. Except in cases of failure, allocation
-	// changes will not be made which would violate having at least this many
-	// ready replicas of an item at all times.
-	Replicas() int
-	// Items which will be created if they do not exist. May be empty, and
-	// additional items may be added at any time out-of-band (via creation of
-	// a corresponding Etcd directory).
-	FixedItems() []string
-
-	// For |item| which is currently a local replica or master, returns a
-	// representation of the local item processing state. State is shared with
-	// other Allocators via this Allocator's |item| announcement in Etcd.
-	ItemState(item string) string
-	// For |state| of an item, which may be processed by another Allocator,
-	// returns whether the item can safely be promoted at this time.
-	ItemIsReadyForPromotion(item, state string) bool
-	// Notifies Allocator of |route| for |item|. If |index| == -1, then Allocator
-	// has no entry for |item|. Otherwise, |route.Entries[index]| is the entry
-	// of this Allocator (and will have basename InstanceKey()). |tree| is given
-	// as context: ItemRoute() will often wish to wish to inspect other state
-	// within |tree| in response to a route change. Note that |route| or |tree|
-	// must be copied if retained beyond this call
-	ItemRoute(item string, route Route, index int, tree *etcd.Node)
-}
-
 // Inspector is an optional interface of an Allocator which allows for
 // inspections of the Allocator state tree.
 type Inspector interface {
@@ -76,7 +46,7 @@ type Inspector interface {
 // |alloc|. If the member lock already exists, returns
 // ErrAllocatorInstanceExists. An Allocator member lock should be obtained
 // prior to an Allocate call.
-func Create(alloc Allocator) error {
+func Create(alloc allocator.Allocator) error {
 	_, err := alloc.KeysAPI().Set(context.Background(), memberKey(alloc), "",
 		&etcd.SetOptions{PrevExist: etcd.PrevNoExist, TTL: lockDuration})
 
@@ -96,7 +66,7 @@ func Create(alloc Allocator) error {
 // process, Allocate will duplicate the item allocations of that process. It is
 // the caller's responsibility to obtain and verify uniqueness of the member
 // lock (eg, via a preceeding Create).
-func Allocate(alloc Allocator) error {
+func Allocate(alloc allocator.Allocator) error {
 	// Channels for receiving & cancelling watched tree updates.
 	var watchCh = make(chan *etcd.Response)
 	var cancelWatch = make(chan struct{})
@@ -246,7 +216,7 @@ func Allocate(alloc Allocator) error {
 // items are released, Allocate() will exit. Note that mastered items will be
 // released only once they have a sufficient number of ready replicas for
 // hand-off.
-func Cancel(alloc Allocator) error {
+func Cancel(alloc allocator.Allocator) error {
 	_, err := alloc.KeysAPI().Delete(context.Background(), memberKey(alloc), nil)
 	return err
 }
@@ -255,7 +225,7 @@ func Cancel(alloc Allocator) error {
 // undertaken only under exceptional circumstances, where the local Allocator
 // is unable to service the allocated |item| (eg, because of an unrecoverable
 // local error).
-func CancelItem(alloc Allocator, item string) error {
+func CancelItem(alloc allocator.Allocator, item string) error {
 	_, err := alloc.KeysAPI().Delete(context.Background(), itemKey(alloc, item), nil)
 	return err
 }
@@ -265,7 +235,7 @@ func CancelItem(alloc Allocator, item string) error {
 // or SIGINT. Performs a polled retry of Create on ErrAllocatorInstanceExists,
 // until aquired or signaled. Top-level programs implementing an Allocator will
 // generally want to use this.
-func CreateAndAllocateWithSignalHandling(alloc Allocator) error {
+func CreateAndAllocateWithSignalHandling(alloc allocator.Allocator) error {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGTERM, syscall.SIGINT)
 	shutdownCh := make(chan struct{})
@@ -311,19 +281,19 @@ func CreateAndAllocateWithSignalHandling(alloc Allocator) error {
 
 // memberKey returns the member announcement key for |alloc|.
 // Ex: /path/root/members/my-alloc-key
-func memberKey(alloc Allocator) string {
+func memberKey(alloc allocator.Allocator) string {
 	return alloc.PathRoot() + "/" + MemberPrefix + "/" + alloc.InstanceKey()
 }
 
 // itemKey returns the item entry key for |item| held by |alloc|.
 // Ex: /path/root/items/an-item/my-alloc-key
-func itemKey(alloc Allocator, item string) string {
+func itemKey(alloc allocator.Allocator, item string) string {
 	return alloc.PathRoot() + "/" + ItemsPrefix + "/" + item + "/" + alloc.InstanceKey()
 }
 
 // itemOfItemKey returns the item name represented by item entry |key| held by
 // |alloc|. Ex: /path/root/items/an-item/my-alloc-key => an-item
-func itemOfItemKey(alloc Allocator, key string) string {
+func itemOfItemKey(alloc allocator.Allocator, key string) string {
 	lstrip := len(alloc.PathRoot()) + 1 + len(ItemsPrefix) + 1
 	rstrip := len(key) - len(alloc.InstanceKey()) - 1
 	return key[lstrip:rstrip]
@@ -332,7 +302,7 @@ func itemOfItemKey(alloc Allocator, key string) string {
 // POD type built by individual iterations of the Allocate() protocol,
 // to succinctly describe global allocator state.
 type allocParams struct {
-	Allocator `json:"-"`
+	allocator.Allocator `json:"-"`
 
 	Input struct {
 		Time  time.Time
@@ -357,7 +327,7 @@ type allocParams struct {
 // WalkItems performs a zipped, outer-join iteration of items under ItemsPrefix
 // of |tree|, and |fixedItems| (which must be ordered). The argument callback
 // |cb| is invoked for each item, and must not retain |route| after each call.
-func WalkItems(tree *etcd.Node, fixedItems []string, cb func(name string, route Route)) {
+func WalkItems(tree *etcd.Node, fixedItems []string, cb func(name string, route allocator.Route)) {
 	var dir etcd.Node
 	if d := Child(tree, ItemsPrefix); d != nil {
 		dir = *d
@@ -367,13 +337,13 @@ func WalkItems(tree *etcd.Node, fixedItems []string, cb func(name string, route 
 	}
 
 	// Perform a zipped, outer-join iteration of |dir| items and |fixedItems|.
-	var scratch [8]*etcd.Node // Re-usable buffer for building Route.Entries.
+	var scratch [8]*etcd.Node // Re-usable buffer for building route.entries.
 	forEachChild(&dir, fixedItems, func(name string, node *etcd.Node) {
 		// Bypass NewRoute to avoid extra deep copies and because we know (per the
 		// callback contract) that |route| will not be retained.
-		var route = Route{
-			Item:    node,
-			Entries: append(scratch[:0], node.Nodes...),
+		var route = route{
+			item:    node,
+			entries: append(scratch[:0], node.Nodes...),
 		}
 		route.init()
 
@@ -385,7 +355,7 @@ func WalkItems(tree *etcd.Node, fixedItems []string, cb func(name string, route 
 // |p.Input|.
 func allocExtract(p *allocParams) {
 
-	WalkItems(p.Input.Tree, p.FixedItems(), func(name string, route Route) {
+	WalkItems(p.Input.Tree, p.FixedItems(), func(name string, route allocator.Route) {
 		p.Item.Count += 1
 
 		var index = route.Index(p.InstanceKey())
@@ -393,26 +363,26 @@ func allocExtract(p *allocParams) {
 
 		if index == -1 {
 			// We do not hold a lock on this item.
-			if len(route.Entries) == 0 {
+			if len(route.Entries()) == 0 {
 				p.Item.OpenMasters = append(p.Item.OpenMasters, name)
-			} else if len(route.Entries) < p.Replicas()+1 {
+			} else if len(route.Entries()) < p.Replicas()+1 {
 				p.Item.OpenReplicas = append(p.Item.OpenReplicas, name)
 			}
 		} else if index == 0 {
 			// We act as item master.
-			p.Item.Master = append(p.Item.Master, route.Entries[0])
+			p.Item.Master = append(p.Item.Master, route.Entries()[0])
 
 			// We always require that mastered items be ready for hand-off
 			// before we may release them, even if our member lock is gone.
 			if route.IsReadyForHandoff(p) {
-				p.Item.Releaseable = append(p.Item.Releaseable, route.Entries[0])
+				p.Item.Releaseable = append(p.Item.Releaseable, route.Entries()[0])
 			}
 		} else if index < p.Replicas()+1 {
 			// We act as an item replica.
-			p.Item.Replica = append(p.Item.Replica, route.Entries[index])
+			p.Item.Replica = append(p.Item.Replica, route.Entries()[index])
 		} else {
 			// We hold an extra lock (we lost a race to become a replica).
-			p.Item.Extra = append(p.Item.Extra, route.Entries[index])
+			p.Item.Extra = append(p.Item.Extra, route.Entries()[index])
 		}
 	})
 

--- a/consensus/allocator.go
+++ b/consensus/allocator.go
@@ -15,8 +15,6 @@ import (
 	"github.com/LiveRamp/gazette/consensus/allocator"
 )
 
-//go:generate mockery -inpkg -name=Allocator
-
 const (
 	MemberPrefix = "members" // Directory root for member announcements.
 	ItemsPrefix  = "items"   // Directory root for allocated items.

--- a/consensus/allocator/interfaces.go
+++ b/consensus/allocator/interfaces.go
@@ -1,0 +1,65 @@
+package allocator
+
+import etcd "github.com/coreos/etcd/client"
+
+// Allocator is an interface which performs distributed allocation of items.
+type Allocator interface {
+	KeysAPI() etcd.KeysAPI
+
+	// Etcd path which roots shared state for this Context.
+	PathRoot() string
+
+	// A key uniquely identifying this Allocator within shared state.
+	InstanceKey() string
+
+	// The required number of replicas. Except in cases of failure, allocation
+	// changes will not be made which would violate having at least this many
+	// ready replicas of an item at all times.
+	Replicas() int
+
+	// Items which will be created if they do not exist. May be empty, and
+	// additional items may be added at any time out-of-band (via creation of
+	// a corresponding Etcd directory).
+	FixedItems() []string
+
+	// For |item| which is currently a local replica or master, returns a
+	// representation of the local item processing state. State is shared with
+	// other Allocators via this Allocator's |item| announcement in Etcd.
+	ItemState(item string) string
+
+	// For |state| of an item, which may be processed by another Allocator,
+	// returns whether the item can safely be promoted at this time.
+	ItemIsReadyForPromotion(item, state string) bool
+
+	// Notifies Allocator of |route| for |item|. If |index| == -1, then Allocator
+	// has no entry for |item|. Otherwise, |route.Entries[index]| is the entry
+	// of this Allocator (and will have basename InstanceKey()). |tree| is given
+	// as context: ItemRoute() will often wish to wish to inspect other state
+	// within |tree| in response to a route change. Note that |route| or |tree|
+	// must be copied if retained beyond this call
+	ItemRoute(item string, route Route, index int, tree *etcd.Node)
+}
+
+// Route represents an agreed-upon, ordered set of responsible processes for an
+// item.
+type Route interface {
+	// Index returns the index of |name| in |rt.Entries()|, or -1.
+	Index(name string) int
+
+	// IsReadyForHandoff returns whether all replicas are ready for the item
+	// master to hand off item responsibility, without causing a violation of the
+	// required replica count.
+	IsReadyForHandoff(alloc Allocator) bool
+
+	// Copy performs a deep-copy of route.
+	Copy() Route
+
+	// Item is the directory Node.
+	Item() *etcd.Node
+
+	// Entries are |Item().Nodes|, ordered on increasing CreatedIndex. 'Master' is
+	// index 0, followed by item replicas. Depending on the target replica count,
+	// there may be additional temporary entries which are neither master nor
+	// replica (eg, due to a lost allocation race).
+	Entries() etcd.Nodes
+}

--- a/consensus/allocator/interfaces.go
+++ b/consensus/allocator/interfaces.go
@@ -2,6 +2,8 @@ package allocator
 
 import etcd "github.com/coreos/etcd/client"
 
+//go:generate mockery -name=Allocator
+
 // Allocator is an interface which performs distributed allocation of items.
 type Allocator interface {
 	KeysAPI() etcd.KeysAPI

--- a/consensus/allocator_run_test.go
+++ b/consensus/allocator_run_test.go
@@ -12,6 +12,7 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
 
+	"github.com/LiveRamp/gazette/consensus/allocator"
 	"github.com/LiveRamp/gazette/envflag"
 	"github.com/LiveRamp/gazette/envflagfactory"
 )
@@ -25,7 +26,7 @@ type AllocRunSuite struct {
 
 	// Tracked state, for verification.
 	routesMu sync.Mutex
-	routes   map[string]Route
+	routes   map[string]allocator.Route
 
 	notifyCh chan notify
 }
@@ -56,7 +57,7 @@ func (s *AllocRunSuite) SetUpTest(c *gc.C) {
 	s.pathRoot = "/tests/" + c.TestName()
 	s.replicas = 0 // Overridden by some tests.
 	s.fixedItems = []string{"bar", "baz", "foo"}
-	s.routes = make(map[string]Route)
+	s.routes = make(map[string]allocator.Route)
 
 	// Clear a previous test Etcd directory (if it exists).
 	s.KeysAPI().Delete(context.Background(), s.pathRoot, &etcd.DeleteOptions{Recursive: true})
@@ -72,7 +73,7 @@ func (s *AllocRunSuite) TestSingle(c *gc.C) {
 	s.wait(waitFor{idle: []string{"my-key"}})
 
 	for _, item := range s.fixedItems {
-		c.Check(s.routes[item].Entries, gc.HasLen, 1)
+		c.Check(s.routes[item].Entries(), gc.HasLen, 1)
 		c.Check(s.routes[item].Index("my-key"), gc.Equals, 0)
 	}
 
@@ -81,7 +82,7 @@ func (s *AllocRunSuite) TestSingle(c *gc.C) {
 
 	alloc.inspectCh <- func(tree *etcd.Node) {
 		var i int
-		WalkItems(tree, nil, func(name string, route Route) {
+		WalkItems(tree, nil, func(name string, route allocator.Route) {
 			c.Check(s.fixedItems[i], gc.Equals, name)
 			c.Check(route.Index("my-key"), gc.Equals, 0)
 			i++
@@ -100,7 +101,7 @@ func (s *AllocRunSuite) TestSingle(c *gc.C) {
 	// Stage 2: Expect that the cancelled item is re-acquired.
 	s.wait(waitFor{idle: []string{"my-key"}})
 
-	c.Check(s.routes["bar"].Entries, gc.HasLen, 1)
+	c.Check(s.routes["bar"].Entries(), gc.HasLen, 1)
 	c.Check(s.routes["bar"].Index("my-key"), gc.Equals, 0)
 	c.Check(Cancel(alloc), gc.IsNil)
 
@@ -108,7 +109,7 @@ func (s *AllocRunSuite) TestSingle(c *gc.C) {
 	s.wait(waitFor{exit: []string{"my-key"}})
 
 	for _, item := range s.fixedItems {
-		c.Check(s.routes[item].Entries, gc.HasLen, 0)
+		c.Check(s.routes[item].Entries(), gc.HasLen, 0)
 	}
 }
 
@@ -129,7 +130,7 @@ func (s *AllocRunSuite) TestHandlingOfNestedItemDirectories(c *gc.C) {
 	s.wait(waitFor{idle: []string{"my-key"}})
 
 	c.Check(s.routes, gc.HasLen, 1)
-	c.Check(s.routes["some"].Entries, gc.HasLen, 2)
+	c.Check(s.routes["some"].Entries(), gc.HasLen, 2)
 	c.Check(s.routes["some"].Index("my-key"), gc.Equals, 1)
 
 	c.Check(Cancel(alloc), gc.IsNil)
@@ -149,7 +150,7 @@ func (s *AllocRunSuite) TestAsyncItemCreationAndRemoval(c *gc.C) {
 
 	c.Check(s.routes, gc.HasLen, 3)
 	for _, route := range s.routes {
-		c.Check(route.Entries, gc.HasLen, 2)
+		c.Check(route.Entries(), gc.HasLen, 2)
 	}
 
 	// Create a new item (by adding its directory).
@@ -161,7 +162,7 @@ func (s *AllocRunSuite) TestAsyncItemCreationAndRemoval(c *gc.C) {
 	s.wait(waitFor{idle: []string{"alloc-1", "alloc-2"}})
 
 	c.Check(s.routes, gc.HasLen, 4)
-	c.Check(s.routes["a-new-item"].Entries, gc.HasLen, 2)
+	c.Check(s.routes["a-new-item"].Entries(), gc.HasLen, 2)
 
 	delete(s.routes, "a-new-item") // Expect ItemRoute("a-new-item") isn't invoked again.
 
@@ -178,7 +179,7 @@ func (s *AllocRunSuite) TestAsyncItemCreationAndRemoval(c *gc.C) {
 	s.wait(waitFor{idle: []string{"alloc-1", "alloc-2"}})
 
 	c.Check(s.routes, gc.HasLen, 3)
-	c.Check(s.routes["bar"].Entries, gc.HasLen, 2)
+	c.Check(s.routes["bar"].Entries(), gc.HasLen, 2)
 
 	// Shut down both allocators.
 	s.replicas = 0
@@ -190,7 +191,7 @@ func (s *AllocRunSuite) TestAsyncItemCreationAndRemoval(c *gc.C) {
 	// Stage 3: Allocator exited. All items were released.
 	c.Check(s.routes, gc.HasLen, 3)
 	for _, route := range s.routes {
-		c.Check(route.Entries, gc.HasLen, 0)
+		c.Check(route.Entries(), gc.HasLen, 0)
 	}
 }
 
@@ -207,7 +208,7 @@ func (s *AllocRunSuite) TestDeadlockSimple(c *gc.C) {
 	// Stage 1: |alloc1| & |alloc2| aquire master and replica on item-1, item-2.
 	s.wait(waitFor{idle: []string{"alloc-1", "alloc-2"}})
 	for _, item := range s.fixedItems {
-		c.Check(s.routes[item].Entries.Len(), gc.Equals, 2)
+		c.Check(s.routes[item].Entries().Len(), gc.Equals, 2)
 	}
 
 	// Stage 2: Start |alloc3|, *then* create a third item (order is important).
@@ -224,11 +225,11 @@ func (s *AllocRunSuite) TestDeadlockSimple(c *gc.C) {
 
 	// Expect that we did not deadlock: that all items are fully replicated
 	for _, route := range s.routes {
-		c.Check(route.Entries.Len(), gc.Equals, 2)
+		c.Check(route.Entries().Len(), gc.Equals, 2)
 	}
 
 	s.replicas = 0 // Allow allocators to exit.
-	for _, a := range []Allocator{alloc1, alloc2, alloc3} {
+	for _, a := range []allocator.Allocator{alloc1, alloc2, alloc3} {
 		c.Check(Cancel(a), gc.IsNil)
 	}
 	s.wait(waitFor{exit: []string{"alloc-1", "alloc-2", "alloc-3"}})
@@ -272,7 +273,7 @@ func (s *AllocRunSuite) TestDeadlockExtended(c *gc.C) {
 
 	// Expect all items are fully replicated.
 	for _, item := range s.fixedItems {
-		c.Check(s.routes[item].Entries.Len(), gc.Equals, 3)
+		c.Check(s.routes[item].Entries().Len(), gc.Equals, 3)
 	}
 
 	// Regression check: experimentally |actions| is in range [2000-2400].
@@ -307,7 +308,7 @@ func (s *AllocRunSuite) TestAllocatorHandoff(c *gc.C) {
 
 	c.Check(s.routes, gc.HasLen, len(s.fixedItems))
 	for _, route := range s.routes {
-		c.Check(route.Entries, gc.HasLen, 2)
+		c.Check(route.Entries(), gc.HasLen, 2)
 	}
 	c.Check(s.masterCounts(), gc.DeepEquals, map[string]int{
 		"alloc-1": 2, // Has larger share, because it was first.
@@ -320,7 +321,7 @@ func (s *AllocRunSuite) TestAllocatorHandoff(c *gc.C) {
 	s.wait(waitFor{exit: []string{"alloc-1"}, idle: []string{"alloc-2", "alloc-3"}})
 
 	for _, route := range s.routes {
-		c.Check(route.Entries, gc.HasLen, 2)
+		c.Check(route.Entries(), gc.HasLen, 2)
 	}
 	c.Check(s.masterCounts(), gc.DeepEquals, map[string]int{
 		"alloc-2": 2, // Has larger share, because it was first.
@@ -332,7 +333,7 @@ func (s *AllocRunSuite) TestAllocatorHandoff(c *gc.C) {
 	s.wait(waitFor{exit: []string{"alloc-2"}, idle: []string{"alloc-3"}})
 
 	for _, route := range s.routes {
-		c.Check(route.Entries, gc.HasLen, 1)
+		c.Check(route.Entries(), gc.HasLen, 1)
 	}
 	c.Check(s.masterCounts(), gc.DeepEquals, map[string]int{"alloc-3": 3})
 
@@ -343,7 +344,7 @@ func (s *AllocRunSuite) TestAllocatorHandoff(c *gc.C) {
 	s.wait(waitFor{exit: []string{"alloc-3"}})
 
 	for _, item := range s.fixedItems {
-		c.Check(s.routes[item].Entries, gc.HasLen, 0)
+		c.Check(s.routes[item].Entries(), gc.HasLen, 0)
 	}
 }
 
@@ -351,7 +352,7 @@ func (t *AllocRunSuite) masterCounts() map[string]int {
 	var counts = make(map[string]int)
 	for _, item := range t.fixedItems {
 		// Group by allocator name, and count.
-		key := t.routes[item].Entries[0].Key
+		key := t.routes[item].Entries()[0].Key
 		counts[key[strings.LastIndexByte(key, '/')+1:]] += 1
 	}
 	return counts
@@ -415,7 +416,7 @@ func (s *AllocRunSuite) ItemIsReadyForPromotion(item, state string) bool {
 	return state == "ready"
 }
 
-func (s *AllocRunSuite) ItemRoute(item string, rt Route, ind int, tree *etcd.Node) {
+func (s *AllocRunSuite) ItemRoute(item string, rt allocator.Route, ind int, tree *etcd.Node) {
 	s.routesMu.Lock()
 	defer s.routesMu.Unlock()
 

--- a/consensus/allocator_test.go
+++ b/consensus/allocator_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/LiveRamp/gazette/consensus/allocator"
 	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
@@ -67,13 +68,13 @@ func (s *AllocSuite) TestAllocParamExtraction(c *gc.C) {
 		name, exp := k, v // Copy and retain for closure.
 		alloc.On("ItemRoute", name, mock.AnythingOfType("route"), exp.ind, params.Input.Tree).
 			Run(func(args mock.Arguments) {
-				rt := args.Get(1).(route)
+				rt := args.Get(1).(allocator.Route)
 
-				c.Check(rt.item.Key, gc.Equals, "/foo/items/"+name)
+				c.Check(rt.Item().Key, gc.Equals, "/foo/items/"+name)
 
-				c.Check(len(rt.entries), gc.Equals, len(exp.keys))
+				c.Check(len(rt.Entries()), gc.Equals, len(exp.keys))
 				for j := range exp.keys {
-					c.Check(rt.entries[j].Key, gc.Equals, rt.item.Key+"/"+exp.keys[j])
+					c.Check(rt.Entries()[j].Key, gc.Equals, rt.Item().Key+"/"+exp.keys[j])
 				}
 			}).Once()
 	}
@@ -113,9 +114,9 @@ func (s *AllocSuite) TestAllocParamExtractionEmptyTree(c *gc.C) {
 	params.Input.Index = 4567
 	params.Input.Tree = &etcd.Node{Dir: true, Key: "/foo"}
 
-	alloc.On("ItemRoute", "a-item", mock.MatchedBy(func(rt route) bool {
-		c.Check(rt.item.Key, gc.Equals, "/foo/items/a-item")
-		c.Check(rt.entries, gc.HasLen, 0)
+	alloc.On("ItemRoute", "a-item", mock.MatchedBy(func(rt allocator.Route) bool {
+		c.Check(rt.Item().Key, gc.Equals, "/foo/items/a-item")
+		c.Check(rt.Entries(), gc.HasLen, 0)
 		return true
 	}), -1, params.Input.Tree)
 

--- a/consensus/allocator_test.go
+++ b/consensus/allocator_test.go
@@ -8,13 +8,14 @@ import (
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/LiveRamp/gazette/consensus/mocks"
+	allocatormocks "github.com/LiveRamp/gazette/consensus/allocator/mocks"
+	consensusmocks "github.com/LiveRamp/gazette/consensus/mocks"
 )
 
 type AllocSuite struct{}
 
 func (s *AllocSuite) TestAllocParamExtraction(c *gc.C) {
-	alloc := &mocks.Allocator{}
+	alloc := &allocatormocks.Allocator{}
 	alloc.On("InstanceKey").Return("my-key")
 	alloc.On("Replicas").Return(1)
 	alloc.On("FixedItems").Return([]string{"a-master", "b-created"})
@@ -64,15 +65,15 @@ func (s *AllocSuite) TestAllocParamExtraction(c *gc.C) {
 	}
 	for k, v := range routeExpectations {
 		name, exp := k, v // Copy and retain for closure.
-		alloc.On("ItemRoute", name, mock.AnythingOfType("Route"), exp.ind, params.Input.Tree).
+		alloc.On("ItemRoute", name, mock.AnythingOfType("route"), exp.ind, params.Input.Tree).
 			Run(func(args mock.Arguments) {
-				rt := args.Get(1).(Route)
+				rt := args.Get(1).(route)
 
-				c.Check(rt.Item.Key, gc.Equals, "/foo/items/"+name)
+				c.Check(rt.item.Key, gc.Equals, "/foo/items/"+name)
 
-				c.Check(len(rt.Entries), gc.Equals, len(exp.keys))
+				c.Check(len(rt.entries), gc.Equals, len(exp.keys))
 				for j := range exp.keys {
-					c.Check(rt.Entries[j].Key, gc.Equals, rt.Item.Key+"/"+exp.keys[j])
+					c.Check(rt.entries[j].Key, gc.Equals, rt.item.Key+"/"+exp.keys[j])
 				}
 			}).Once()
 	}
@@ -102,7 +103,7 @@ func (s *AllocSuite) TestAllocParamExtraction(c *gc.C) {
 }
 
 func (s *AllocSuite) TestAllocParamExtractionEmptyTree(c *gc.C) {
-	alloc := &mocks.Allocator{}
+	alloc := &allocatormocks.Allocator{}
 
 	alloc.On("InstanceKey").Return("my-key")
 	alloc.On("FixedItems").Return([]string{"a-item"})
@@ -112,9 +113,9 @@ func (s *AllocSuite) TestAllocParamExtractionEmptyTree(c *gc.C) {
 	params.Input.Index = 4567
 	params.Input.Tree = &etcd.Node{Dir: true, Key: "/foo"}
 
-	alloc.On("ItemRoute", "a-item", mock.MatchedBy(func(rt Route) bool {
-		c.Check(rt.Item.Key, gc.Equals, "/foo/items/a-item")
-		c.Check(rt.Entries, gc.HasLen, 0)
+	alloc.On("ItemRoute", "a-item", mock.MatchedBy(func(rt route) bool {
+		c.Check(rt.item.Key, gc.Equals, "/foo/items/a-item")
+		c.Check(rt.entries, gc.HasLen, 0)
 		return true
 	}), -1, params.Input.Tree)
 
@@ -134,7 +135,7 @@ func (s *AllocSuite) TestAllocParamExtractionEmptyTree(c *gc.C) {
 }
 
 func (s *AllocSuite) TestDesiredCounts(c *gc.C) {
-	var mockAlloc mocks.Allocator
+	var mockAlloc allocatormocks.Allocator
 	var p = allocParams{Allocator: &mockAlloc}
 
 	mockAlloc.On("Replicas").Return(2)
@@ -161,8 +162,8 @@ func (s *AllocSuite) TestDesiredCounts(c *gc.C) {
 }
 
 func (s *AllocSuite) TestAllocationActions(c *gc.C) {
-	var mockKV mocks.KeysAPI
-	var mockAlloc mocks.Allocator
+	var mockKV consensusmocks.KeysAPI
+	var mockAlloc allocatormocks.Allocator
 
 	var model allocParams
 	model.Allocator = &mockAlloc

--- a/consensus/allocator_test.go
+++ b/consensus/allocator_test.go
@@ -7,12 +7,14 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/LiveRamp/gazette/consensus/mocks"
 )
 
 type AllocSuite struct{}
 
 func (s *AllocSuite) TestAllocParamExtraction(c *gc.C) {
-	alloc := &MockAllocator{}
+	alloc := &mocks.Allocator{}
 	alloc.On("InstanceKey").Return("my-key")
 	alloc.On("Replicas").Return(1)
 	alloc.On("FixedItems").Return([]string{"a-master", "b-created"})
@@ -100,7 +102,7 @@ func (s *AllocSuite) TestAllocParamExtraction(c *gc.C) {
 }
 
 func (s *AllocSuite) TestAllocParamExtractionEmptyTree(c *gc.C) {
-	alloc := &MockAllocator{}
+	alloc := &mocks.Allocator{}
 
 	alloc.On("InstanceKey").Return("my-key")
 	alloc.On("FixedItems").Return([]string{"a-item"})
@@ -132,7 +134,7 @@ func (s *AllocSuite) TestAllocParamExtractionEmptyTree(c *gc.C) {
 }
 
 func (s *AllocSuite) TestDesiredCounts(c *gc.C) {
-	var mockAlloc MockAllocator
+	var mockAlloc mocks.Allocator
 	var p = allocParams{Allocator: &mockAlloc}
 
 	mockAlloc.On("Replicas").Return(2)
@@ -159,8 +161,8 @@ func (s *AllocSuite) TestDesiredCounts(c *gc.C) {
 }
 
 func (s *AllocSuite) TestAllocationActions(c *gc.C) {
-	var mockKV MockKeysAPI
-	var mockAlloc MockAllocator
+	var mockKV mocks.KeysAPI
+	var mockAlloc mocks.Allocator
 
 	var model allocParams
 	model.Allocator = &mockAlloc

--- a/consensus/retry_watcher_test.go
+++ b/consensus/retry_watcher_test.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"errors"
 
+	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
 
-	etcd "github.com/coreos/etcd/client"
+	"github.com/LiveRamp/gazette/consensus/mocks"
 )
 
 type RetryWatcherSuite struct{}
 
 func (s *RetryWatcherSuite) TestFoo(c *gc.C) {
 	var ctx = context.Background()
-	var keys MockKeysAPI
-	var watcher MockWatcher
+	var keys mocks.KeysAPI
+	var watcher mocks.Watcher
 
 	var rwatcher = RetryWatcher(&keys, "/key",
 		&etcd.GetOptions{Recursive: true},

--- a/consensus/route.go
+++ b/consensus/route.go
@@ -4,52 +4,46 @@ import (
 	"path"
 	"sort"
 
+	"github.com/LiveRamp/gazette/consensus/allocator"
 	etcd "github.com/coreos/etcd/client"
 )
 
-// Route represents an agreed-upon, ordered set of responsible processes for an item.
-type Route struct {
-	// Directory Node of item.
-	Item *etcd.Node
-	// Entries of |Item.Nodes|, ordered on increasing CreatedIndex. 'Master' is
-	// index 0, followed by item replicas. Depending on the target replica count,
-	// there may be additional temporary entries which are neither master nor
-	// replica (eg, due to a lost allocation race).
-	Entries etcd.Nodes
+// route implements allocator.Route
+type route struct {
+	item    *etcd.Node
+	entries etcd.Nodes
 }
 
-// NewRoute initializes a new Route from the |response| and |node|.
-func NewRoute(response *etcd.Response, node *etcd.Node) Route {
-	rt := Route{
-		Item:    node,
-		Entries: append(etcd.Nodes{}, node.Nodes...), // Copy, as we'll re-order.
+// NewRoute initializes a new route from the |response| and |node|.
+func NewRoute(response *etcd.Response, node *etcd.Node) allocator.Route {
+	rt := route{
+		item:    node,
+		entries: append(etcd.Nodes{}, node.Nodes...), // Copy, as we'll re-order.
 	}
 	rt.init()
 	return rt
 }
 
-// Index returns the index of |name| in |rt.Entries|, or -1.
-func (rt Route) Index(name string) int {
-	prefix := len(rt.Item.Key) + 1
-	for ind := range rt.Entries {
-		if rt.Entries[ind].Key[prefix:] == name {
+// Index implements allocator.Route
+func (rt route) Index(name string) int {
+	prefix := len(rt.item.Key) + 1
+	for ind := range rt.entries {
+		if rt.entries[ind].Key[prefix:] == name {
 			return ind
 		}
 	}
 	return -1
 }
 
-// IsReadyForHandoff returns whether all replicas are ready for the item
-// master to hand off item responsibility, without causing a violation of the
-// required replica count.
-func (rt Route) IsReadyForHandoff(alloc Allocator) bool {
-	if wanted := alloc.Replicas() + 1; len(rt.Entries) < wanted {
+// IsReadyForHandoff implements allocator.Route
+func (rt route) IsReadyForHandoff(alloc allocator.Allocator) bool {
+	if wanted := alloc.Replicas() + 1; len(rt.entries) < wanted {
 		return false
 	} else {
-		item := path.Base(rt.Item.Key)
+		item := path.Base(rt.item.Key)
 
 		for j := 1; j != wanted; j++ {
-			if !alloc.ItemIsReadyForPromotion(item, rt.Entries[j].Value) {
+			if !alloc.ItemIsReadyForPromotion(item, rt.entries[j].Value) {
 				return false
 			}
 		}
@@ -57,16 +51,26 @@ func (rt Route) IsReadyForHandoff(alloc Allocator) bool {
 	}
 }
 
-// Copy performs a deep-copy of Route.
-func (rt Route) Copy() Route {
-	return Route{
-		Item:    CopyNode(rt.Item),
-		Entries: CopyNodes(rt.Entries),
+// Copy implements allocator.Route
+func (rt route) Copy() allocator.Route {
+	return route{
+		item:    CopyNode(rt.item),
+		entries: CopyNodes(rt.entries),
 	}
 }
 
-func (rt Route) init() {
-	sort.Sort(createdIndexOrder(rt.Entries))
+// Item implements allocator.Route
+func (rt route) Item() *etcd.Node {
+	return rt.item
+}
+
+// Entries implements allocator.Route
+func (rt route) Entries() etcd.Nodes {
+	return rt.entries
+}
+
+func (rt route) init() {
+	sort.Sort(createdIndexOrder(rt.entries))
 }
 
 // createdIndexOrder implements sort.Interface, ordering by increasing CreatedIndex.

--- a/consensus/route.go
+++ b/consensus/route.go
@@ -4,8 +4,9 @@ import (
 	"path"
 	"sort"
 
-	"github.com/LiveRamp/gazette/consensus/allocator"
 	etcd "github.com/coreos/etcd/client"
+
+	"github.com/LiveRamp/gazette/consensus/allocator"
 )
 
 // route implements allocator.Route

--- a/consensus/route_test.go
+++ b/consensus/route_test.go
@@ -4,7 +4,7 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
 
-	"github.com/LiveRamp/gazette/consensus/mocks"
+	"github.com/LiveRamp/gazette/consensus/allocator/mocks"
 )
 
 type RouteSuite struct{}
@@ -12,9 +12,9 @@ type RouteSuite struct{}
 func (s *RouteSuite) TestOrdering(c *gc.C) {
 	rt := s.fixture()
 
-	c.Check(rt.Entries[0].Key, gc.Equals, "/foo/bar/ccc")
-	c.Check(rt.Entries[1].Key, gc.Equals, "/foo/bar/aaa")
-	c.Check(rt.Entries[2].Key, gc.Equals, "/foo/bar/bbb")
+	c.Check(rt.entries[0].Key, gc.Equals, "/foo/bar/ccc")
+	c.Check(rt.entries[1].Key, gc.Equals, "/foo/bar/aaa")
+	c.Check(rt.entries[2].Key, gc.Equals, "/foo/bar/bbb")
 }
 
 func (s *RouteSuite) TestIndex(c *gc.C) {
@@ -54,13 +54,13 @@ func (s *RouteSuite) TestCopy(c *gc.C) {
 	rt1 := s.fixture()
 	rt2 := rt1.Copy()
 
-	// Expect |rt2| has distinct Entries storage from |rt1|.
+	// Expect |rt2| has distinct entries storage from |rt1|.
 	c.Check(rt1, gc.DeepEquals, rt2)
-	rt1.Entries[0], rt1.Entries[1] = rt1.Entries[1], rt1.Entries[0]
+	rt1.entries[0], rt1.entries[1] = rt1.entries[1], rt1.entries[0]
 	c.Check(rt1, gc.Not(gc.DeepEquals), rt2)
 }
 
-func (s *RouteSuite) fixture() Route {
+func (s *RouteSuite) fixture() route {
 	item := &etcd.Node{
 		Key: "/foo/bar",
 		Nodes: []*etcd.Node{
@@ -70,9 +70,9 @@ func (s *RouteSuite) fixture() Route {
 		},
 	}
 
-	rt := Route{
-		Item:    item,
-		Entries: append([]*etcd.Node{}, item.Nodes...),
+	rt := route{
+		item:    item,
+		entries: append([]*etcd.Node{}, item.Nodes...),
 	}
 	rt.init()
 

--- a/consensus/route_test.go
+++ b/consensus/route_test.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
+
+	"github.com/LiveRamp/gazette/consensus/mocks"
 )
 
 type RouteSuite struct{}
@@ -26,7 +28,7 @@ func (s *RouteSuite) TestIndex(c *gc.C) {
 
 func (s *RouteSuite) TestReadyForHandoff(c *gc.C) {
 	rt := s.fixture()
-	alloc := &MockAllocator{}
+	alloc := &mocks.Allocator{}
 
 	// No replicas required: always ready for handoff.
 	alloc.On("Replicas").Return(0).Once()

--- a/consensus/tree_ops.go
+++ b/consensus/tree_ops.go
@@ -10,8 +10,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-//go:generate mockery -inpkg -name=KeysAPI
-//go:generate mockery -inpkg -name=Watcher
+//go:generate mockery -name=KeysAPI
+//go:generate mockery -name=Watcher
 
 var (
 	etcdUpsertOps = map[string]struct{}{

--- a/consensus/watcher_test.go
+++ b/consensus/watcher_test.go
@@ -6,14 +6,16 @@ import (
 
 	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
+
+	"github.com/LiveRamp/gazette/consensus/mocks"
 )
 
 type ModelSuite struct{}
 
 func (s *ModelSuite) TestBlockUntilModified(c *gc.C) {
 	var ctx = context.Background()
-	var keys MockKeysAPI
-	var watcher MockWatcher
+	var keys mocks.KeysAPI
+	var watcher mocks.Watcher
 
 	var modelWatcher = RetryWatcher(&keys, "foo",
 		&etcd.GetOptions{}, &etcd.WatcherOptions{})

--- a/consumer/client_test.go
+++ b/consumer/client_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 
-	"github.com/LiveRamp/gazette/consumer/mocks"
+	"github.com/LiveRamp/gazette/consumer/service"
+	"github.com/LiveRamp/gazette/consumer/service/mocks"
 )
 
 type ClientSuite struct{}
@@ -18,7 +19,7 @@ func (s *ClientSuite) TestClientInitializationAndUpdate(c *gc.C) {
 	defer s0.srv.GracefulStop()
 	defer s1.srv.GracefulStop()
 
-	s0.mock.On("CurrentConsumerState", mock.Anything, &Empty{}).Return(
+	s0.mock.On("CurrentConsumerState", mock.Anything, &service.Empty{}).Return(
 		buildConsumerStateFixture(s0.addr, s1.addr), nil).Once()
 
 	var client, err = NewClient(s0.addr)
@@ -30,17 +31,17 @@ func (s *ClientSuite) TestClientInitializationAndUpdate(c *gc.C) {
 	conn, shard, err := client.PartitionClient("partition/zero")
 	c.Check(err, gc.IsNil)
 	c.Check(conn, gc.NotNil)
-	c.Check(shard.Id, gc.Equals, ShardID("shard-zero"))
+	c.Check(shard.Id, gc.Equals, service.ShardID("shard-zero"))
 
 	conn, shard, err = client.PartitionClient("partition/one")
 	c.Check(err, gc.Equals, ErrNoReadyPartitionClient)
 	c.Check(conn, gc.IsNil)
-	c.Check(shard.Id, gc.Equals, ShardID("shard-one"))
+	c.Check(shard.Id, gc.Equals, service.ShardID("shard-one"))
 
 	conn, shard, err = client.PartitionClient("partition/two")
 	c.Check(err, gc.Equals, ErrNoReadyPartitionClient)
 	c.Check(conn, gc.IsNil)
-	c.Check(shard.Id, gc.Equals, ShardID("shard-two"))
+	c.Check(shard.Id, gc.Equals, service.ShardID("shard-two"))
 
 	conn, shard, err = client.PartitionClient("partition/three")
 	c.Check(err, gc.Equals, ErrNoSuchConsumerPartition)
@@ -53,18 +54,18 @@ func (s *ClientSuite) TestClientInitializationAndUpdate(c *gc.C) {
 	var fixture = buildConsumerStateFixture(s0.addr, s1.addr)
 
 	fixture.Endpoints = sortStrings([]string{s0.addr, s1.addr, s2.addr})
-	fixture.Shards = append(fixture.Shards, ConsumerState_Shard{
+	fixture.Shards = append(fixture.Shards, service.ConsumerState_Shard{
 		Id:        "shard-three",
 		Topic:     "a/topic",
 		Partition: "partition/three",
-		Replicas: []ConsumerState_Replica{
+		Replicas: []service.ConsumerState_Replica{
 			{
 				Endpoint: s2.addr,
-				Status:   ConsumerState_Replica_PRIMARY,
+				Status:   service.ConsumerState_Replica_PRIMARY,
 			},
 		},
 	})
-	s0.mock.On("CurrentConsumerState", mock.Anything, &Empty{}).Return(fixture, nil).Once()
+	s0.mock.On("CurrentConsumerState", mock.Anything, &service.Empty{}).Return(fixture, nil).Once()
 
 	c.Check(client.update(), gc.IsNil)
 
@@ -72,12 +73,12 @@ func (s *ClientSuite) TestClientInitializationAndUpdate(c *gc.C) {
 	conn, shard, err = client.PartitionClient("partition/zero")
 	c.Check(err, gc.IsNil)
 	c.Check(conn, gc.NotNil)
-	c.Check(shard.Id, gc.Equals, ShardID("shard-zero"))
+	c.Check(shard.Id, gc.Equals, service.ShardID("shard-zero"))
 
 	conn, shard, err = client.PartitionClient("partition/three")
 	c.Check(err, gc.IsNil)
 	c.Check(conn, gc.NotNil)
-	c.Check(shard.Id, gc.Equals, ShardID("shard-three"))
+	c.Check(shard.Id, gc.Equals, service.ShardID("shard-three"))
 }
 
 type mockConsumerServer struct {
@@ -88,9 +89,9 @@ type mockConsumerServer struct {
 
 func buildMockServer(c *gc.C) mockConsumerServer {
 	var srv = grpc.NewServer()
-	var m = new(MockConsumerServer)
+	var m = new(mocks.ConsumerServer)
 
-	RegisterConsumerServer(srv, m)
+	service.RegisterConsumerServer(srv, m)
 
 	var l, err = net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, gc.IsNil)
@@ -104,26 +105,26 @@ func buildMockServer(c *gc.C) mockConsumerServer {
 	}
 }
 
-func buildConsumerStateFixture(addr0, addr1 string) *ConsumerState {
-	return &ConsumerState{
+func buildConsumerStateFixture(addr0, addr1 string) *service.ConsumerState {
+	return &service.ConsumerState{
 		Root:          "a/root",
 		LocalRouteKey: addr0,
 		ReplicaCount:  1,
 		Endpoints:     []string{addr0, addr1},
-		Shards: []ConsumerState_Shard{
+		Shards: []service.ConsumerState_Shard{
 			// shard-zero is PRIMARY and addressable.
 			{
 				Id:        "shard-zero",
 				Topic:     "a/topic",
 				Partition: "partition/zero",
-				Replicas: []ConsumerState_Replica{
+				Replicas: []service.ConsumerState_Replica{
 					{
 						Endpoint: addr1,
-						Status:   ConsumerState_Replica_PRIMARY,
+						Status:   service.ConsumerState_Replica_PRIMARY,
 					},
 					{
 						Endpoint: addr0,
-						Status:   ConsumerState_Replica_RECOVERING,
+						Status:   service.ConsumerState_Replica_RECOVERING,
 					},
 				},
 			},
@@ -132,10 +133,10 @@ func buildConsumerStateFixture(addr0, addr1 string) *ConsumerState {
 				Id:        "shard-one",
 				Topic:     "a/topic",
 				Partition: "partition/one",
-				Replicas: []ConsumerState_Replica{
+				Replicas: []service.ConsumerState_Replica{
 					{
 						Endpoint: addr0,
-						Status:   ConsumerState_Replica_RECOVERING,
+						Status:   service.ConsumerState_Replica_RECOVERING,
 					},
 				},
 			},
@@ -144,10 +145,10 @@ func buildConsumerStateFixture(addr0, addr1 string) *ConsumerState {
 				Id:        "shard-two",
 				Topic:     "a/topic",
 				Partition: "partition/two",
-				Replicas: []ConsumerState_Replica{
+				Replicas: []service.ConsumerState_Replica{
 					{
 						Endpoint: "[100::1]:1234", // RFC 6666 black-hole IP.
-						Status:   ConsumerState_Replica_PRIMARY,
+						Status:   service.ConsumerState_Replica_PRIMARY,
 					},
 				},
 			},

--- a/consumer/client_test.go
+++ b/consumer/client_test.go
@@ -7,6 +7,8 @@ import (
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+
+	"github.com/LiveRamp/gazette/consumer/mocks"
 )
 
 type ClientSuite struct{}
@@ -80,7 +82,7 @@ func (s *ClientSuite) TestClientInitializationAndUpdate(c *gc.C) {
 
 type mockConsumerServer struct {
 	srv  *grpc.Server
-	mock *MockConsumerServer
+	mock *mocks.ConsumerServer
 	addr string
 }
 

--- a/consumer/consumertest/shard.go
+++ b/consumer/consumertest/shard.go
@@ -6,14 +6,14 @@ import (
 
 	rocks "github.com/tecbot/gorocksdb"
 
-	"github.com/LiveRamp/gazette/consumer"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/topic"
 )
 
 // Test type which conforms to consumer.Shard, and manages setup & teardown
 // of a test RocksDB instance.
 type Shard struct {
-	IDFixture        consumer.ShardID
+	IDFixture        service.ShardID
 	PartitionFixture topic.Partition
 
 	tmpdir string
@@ -30,7 +30,7 @@ type Shard struct {
 }
 
 // consumer.Shard implementation.
-func (s *Shard) ID() consumer.ShardID              { return s.IDFixture }
+func (s *Shard) ID() service.ShardID               { return s.IDFixture }
 func (s *Shard) Partition() topic.Partition        { return s.PartitionFixture }
 func (s *Shard) Cache() interface{}                { return s.cache }
 func (s *Shard) SetCache(c interface{})            { s.cache = c }

--- a/consumer/database_test.go
+++ b/consumer/database_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/LiveRamp/gazette/journal/mocks"
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
 	rocks "github.com/tecbot/gorocksdb"
@@ -31,7 +32,7 @@ func (s *DatabaseSuite) TestDatabase(c *gc.C) {
 	}
 	close(result.Ready)
 
-	var writer = &journal.MockWriter{}
+	var writer = &mocks.Writer{}
 	writer.On("Write", logName, mock.AnythingOfType("[]uint8")).Return(&result, nil)
 	writer.On("ReadFrom", logName, mock.Anything).Return(&result, nil)
 

--- a/consumer/integration_test.go
+++ b/consumer/integration_test.go
@@ -15,12 +15,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/LiveRamp/gazette/consumer/service"
 	etcd "github.com/coreos/etcd/client"
 	gc "github.com/go-check/check"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/LiveRamp/gazette/consensus"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/envflag"
 	"github.com/LiveRamp/gazette/envflagfactory"
 	"github.com/LiveRamp/gazette/gazette"

--- a/consumer/pump_test.go
+++ b/consumer/pump_test.go
@@ -8,6 +8,7 @@ import (
 	gc "github.com/go-check/check"
 
 	"github.com/LiveRamp/gazette/journal"
+	"github.com/LiveRamp/gazette/journal/mocks"
 	"github.com/LiveRamp/gazette/topic"
 )
 
@@ -23,7 +24,7 @@ func (s *PumpSuite) TestPump(c *gc.C) {
 	}{bytes.NewReader(bytes.Repeat(buffer, 3)), make(closeCh)}
 
 	// Return a result fixture which skips forward from 0 => 1234.
-	var getter journal.MockGetter
+	var getter mocks.Getter
 	getter.On("Get", journal.ReadArgs{
 		Journal:  "a/journal",
 		Offset:   0,

--- a/consumer/replica.go
+++ b/consumer/replica.go
@@ -4,11 +4,12 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/recoverylog"
 )
 
 type replica struct {
-	shard     ShardID
+	shard     service.ShardID
 	player    *recoverylog.Player
 	servingCh chan struct{} // Blocks until replica.serve exists.
 }

--- a/consumer/routines.go
+++ b/consumer/routines.go
@@ -8,13 +8,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
 	rocks "github.com/tecbot/gorocksdb"
 
 	"github.com/LiveRamp/gazette/consensus"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/journal"
 	"github.com/LiveRamp/gazette/recoverylog"
 	"github.com/LiveRamp/gazette/topic"

--- a/consumer/routines_test.go
+++ b/consumer/routines_test.go
@@ -13,25 +13,26 @@ import (
 	"github.com/stretchr/testify/mock"
 	rocks "github.com/tecbot/gorocksdb"
 
-	"github.com/LiveRamp/gazette/consensus"
+	"github.com/LiveRamp/gazette/consensus/mocks"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/journal"
 	"github.com/LiveRamp/gazette/recoverylog"
 	"github.com/LiveRamp/gazette/topic"
 )
 
 type RoutinesSuite struct {
-	keysAPI *consensus.MockKeysAPI
+	keysAPI *mocks.KeysAPI
 }
 
 var (
-	id8  = ShardID("shard-foo-008")
-	id12 = ShardID("shard-baz-012")
-	id30 = ShardID("shard-bar-030")
-	id42 = ShardID("shard-quux-042")
+	id8  = service.ShardID("shard-foo-008")
+	id12 = service.ShardID("shard-baz-012")
+	id30 = service.ShardID("shard-bar-030")
+	id42 = service.ShardID("shard-quux-042")
 )
 
 func (s *RoutinesSuite) SetUpTest(c *gc.C) {
-	s.keysAPI = new(consensus.MockKeysAPI)
+	s.keysAPI = new(mocks.KeysAPI)
 }
 
 func (s *RoutinesSuite) TestShardName(c *gc.C) {
@@ -206,7 +207,7 @@ func (s *RoutinesSuite) TestTopicShardMapping(c *gc.C) {
 	var shards = EnumerateShards(&consumer)
 	c.Check(shards, gc.HasLen, 7)
 
-	c.Check(shards, gc.DeepEquals, map[ShardID]topic.Partition{
+	c.Check(shards, gc.DeepEquals, map[service.ShardID]topic.Partition{
 		"shard-add-subtract-updates-000": {Journal: "pippio-journals/integration-tests/add-subtract-updates/part-000", Topic: addSubTopic},
 		"shard-add-subtract-updates-001": {Journal: "pippio-journals/integration-tests/add-subtract-updates/part-001", Topic: addSubTopic},
 		"shard-add-subtract-updates-002": {Journal: "pippio-journals/integration-tests/add-subtract-updates/part-002", Topic: addSubTopic},

--- a/consumer/runner.go
+++ b/consumer/runner.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/LiveRamp/gazette/consensus"
+	"github.com/LiveRamp/gazette/consensus/allocator"
 	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/journal"
 	"github.com/LiveRamp/gazette/topic"
@@ -74,7 +75,7 @@ func (r *Runner) CurrentConsumerState(context.Context, *service.Empty) (*service
 			// Member Nodes are already sorted on node Key.
 			out.Endpoints = append(out.Endpoints, path.Base(n.Key))
 		}
-		consensus.WalkItems(tree, r.FixedItems(), func(name string, route consensus.Route) {
+		consensus.WalkItems(tree, r.FixedItems(), func(name string, route allocator.Route) {
 			var shardID = service.ShardID(name)
 
 			var partition, ok = r.allShards[shardID]
@@ -88,7 +89,7 @@ func (r *Runner) CurrentConsumerState(context.Context, *service.Empty) (*service
 				Partition: partition.Journal,
 			}
 
-			for _, e := range route.Entries {
+			for _, e := range route.Entries() {
 				var replica = service.ConsumerState_Replica{
 					Endpoint: path.Base(e.Key),
 				}
@@ -199,7 +200,7 @@ func (r *Runner) ItemIsReadyForPromotion(item, state string) bool {
 	return state == Ready
 }
 
-func (r *Runner) ItemRoute(name string, rt consensus.Route, index int, tree *etcd.Node) {
+func (r *Runner) ItemRoute(name string, rt allocator.Route, index int, tree *etcd.Node) {
 	var id = service.ShardID(name)
 	var current, exists = r.liveShards[id]
 

--- a/consumer/runner.go
+++ b/consumer/runner.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/LiveRamp/gazette/consensus"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/journal"
 	"github.com/LiveRamp/gazette/topic"
 )
@@ -27,7 +28,7 @@ const (
 )
 
 type Runner struct {
-	Consumer Consumer
+	Consumer service.Consumer
 	// An identifier for this particular runner. Eg, the hostname.
 	LocalRouteKey string
 	// Base local directory into which shards should be staged.
@@ -44,23 +45,23 @@ type Runner struct {
 
 	// Optional hooks for notification of Shard lifecycle. These are largely
 	// intended to facilitate testing cases.
-	ShardPostInitHook    func(Shard)
-	ShardPostConsumeHook func(topic.Envelope, Shard)
-	ShardPostCommitHook  func(Shard)
-	ShardPostStopHook    func(Shard)
+	ShardPostInitHook    func(service.Shard)
+	ShardPostConsumeHook func(topic.Envelope, service.Shard)
+	ShardPostCommitHook  func(service.Shard)
+	ShardPostStopHook    func(service.Shard)
 
 	partitions map[journal.Name]*topic.Description // Previously enumerated topic partitions.
 	shardNames []string                            // Allocator FixedItems support.
 
-	allShards    map[ShardID]topic.Partition // All shards and their Partition, by name.
-	liveShards   map[ShardID]*shard          // Live shards, by name.
-	zombieShards map[*shard]struct{}         // Cancelled shards which are shutting down.
+	allShards    map[service.ShardID]topic.Partition // All shards and their Partition, by name.
+	liveShards   map[service.ShardID]*shard          // Live shards, by name.
+	zombieShards map[*shard]struct{}                 // Cancelled shards which are shutting down.
 
 	inspectCh chan func(*etcd.Node)
 }
 
-func (r *Runner) CurrentConsumerState(context.Context, *Empty) (*ConsumerState, error) {
-	var out = &ConsumerState{
+func (r *Runner) CurrentConsumerState(context.Context, *service.Empty) (*service.ConsumerState, error) {
+	var out = &service.ConsumerState{
 		Root:          r.ConsumerRoot,
 		LocalRouteKey: r.LocalRouteKey,
 		ReplicaCount:  int32(r.ReplicaCount),
@@ -74,33 +75,33 @@ func (r *Runner) CurrentConsumerState(context.Context, *Empty) (*ConsumerState, 
 			out.Endpoints = append(out.Endpoints, path.Base(n.Key))
 		}
 		consensus.WalkItems(tree, r.FixedItems(), func(name string, route consensus.Route) {
-			var shardID = ShardID(name)
+			var shardID = service.ShardID(name)
 
 			var partition, ok = r.allShards[shardID]
 			if !ok {
 				return
 			}
 
-			var shard = ConsumerState_Shard{
+			var shard = service.ConsumerState_Shard{
 				Id:        shardID,
 				Topic:     partition.Topic.Name,
 				Partition: partition.Journal,
 			}
 
 			for _, e := range route.Entries {
-				var replica = ConsumerState_Replica{
+				var replica = service.ConsumerState_Replica{
 					Endpoint: path.Base(e.Key),
 				}
 
 				switch e.Value {
 				case Primary:
-					replica.Status = ConsumerState_Replica_PRIMARY
+					replica.Status = service.ConsumerState_Replica_PRIMARY
 				case Ready:
-					replica.Status = ConsumerState_Replica_READY
+					replica.Status = service.ConsumerState_Replica_READY
 				case Recovering:
-					replica.Status = ConsumerState_Replica_RECOVERING
+					replica.Status = service.ConsumerState_Replica_RECOVERING
 				default:
-					replica.Status = ConsumerState_Replica_INVALID
+					replica.Status = service.ConsumerState_Replica_INVALID
 				}
 				shard.Replicas = append(shard.Replicas, replica)
 			}
@@ -145,8 +146,8 @@ func (r *Runner) Run() error {
 	}
 
 	r.partitions = make(map[journal.Name]*topic.Description)
-	r.allShards = make(map[ShardID]topic.Partition)
-	r.liveShards = make(map[ShardID]*shard)
+	r.allShards = make(map[service.ShardID]topic.Partition)
+	r.liveShards = make(map[service.ShardID]*shard)
 	r.zombieShards = make(map[*shard]struct{})
 	r.inspectCh = make(chan func(*etcd.Node))
 
@@ -183,7 +184,7 @@ func (r *Runner) PathRoot() string      { return r.ConsumerRoot }
 func (r *Runner) Replicas() int         { return r.ReplicaCount }
 
 func (r *Runner) ItemState(name string) string {
-	if shard, ok := r.liveShards[ShardID(name)]; !ok {
+	if shard, ok := r.liveShards[service.ShardID(name)]; !ok {
 		return UnknownShard
 	} else if shard.master != nil && shard.master.didFinishInit() {
 		return Primary
@@ -199,7 +200,7 @@ func (r *Runner) ItemIsReadyForPromotion(item, state string) bool {
 }
 
 func (r *Runner) ItemRoute(name string, rt consensus.Route, index int, tree *etcd.Node) {
-	var id = ShardID(name)
+	var id = service.ShardID(name)
 	var current, exists = r.liveShards[id]
 
 	// |index| captures the allocator's role in processing |current|.

--- a/consumer/service/interfaces.go
+++ b/consumer/service/interfaces.go
@@ -1,4 +1,4 @@
-package consumer
+package service
 
 import (
 	rocks "github.com/tecbot/gorocksdb"
@@ -7,6 +7,11 @@ import (
 )
 
 //go:generate mockery -inpkg -name=Shard
+
+// ConsumerServer is generated from service.proto. This go:generate directive
+// is placed here to avoid relying on the protobuf compiler to propagate it to
+// generated Go source.
+//go:generate mockery -inpkg -name=ConsumerServer
 
 // ShardID uniquely identifies a specific Shard. A ShardID must be consistent
 // across processes for the entire duration of the Consumer lifetime.

--- a/consumer/service/interfaces.go
+++ b/consumer/service/interfaces.go
@@ -6,12 +6,12 @@ import (
 	"github.com/LiveRamp/gazette/topic"
 )
 
-//go:generate mockery -inpkg -name=Shard
+//go:generate mockery -name=Shard
 
 // ConsumerServer is generated from service.proto. This go:generate directive
 // is placed here to avoid relying on the protobuf compiler to propagate it to
 // generated Go source.
-//go:generate mockery -inpkg -name=ConsumerServer
+//go:generate mockery -name=ConsumerServer
 
 // ShardID uniquely identifies a specific Shard. A ShardID must be consistent
 // across processes for the entire duration of the Consumer lifetime.

--- a/consumer/service/service.proto
+++ b/consumer/service/service.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package consumer;
+package service;
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 

--- a/consumer/shard.go
+++ b/consumer/shard.go
@@ -3,10 +3,10 @@ package consumer
 import (
 	"path/filepath"
 
-	"github.com/LiveRamp/gazette/consumer/service"
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/topic"
 )
 

--- a/consumer/shard.go
+++ b/consumer/shard.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"path/filepath"
 
+	"github.com/LiveRamp/gazette/consumer/service"
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
 
@@ -21,7 +22,7 @@ const (
 // Models the state-machine of how a shard transitions from replica, to master,
 // to cancelled. Delegates out the interesting bits to `replica` and `master`.
 type shard struct {
-	id        ShardID
+	id        service.ShardID
 	partition topic.Partition
 
 	localDir string
@@ -40,7 +41,7 @@ type shard struct {
 	cancelCh chan struct{}
 }
 
-func newShard(id ShardID, partition topic.Partition, runner *Runner, zombie *shard) *shard {
+func newShard(id service.ShardID, partition topic.Partition, runner *Runner, zombie *shard) *shard {
 	return &shard{
 		cancelCh:  make(chan struct{}),
 		id:        id,

--- a/consumer/shard_index.go
+++ b/consumer/shard_index.go
@@ -3,8 +3,9 @@ package consumer
 import (
 	"sync"
 
-	"github.com/LiveRamp/gazette/consumer/service"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/LiveRamp/gazette/consumer/service"
 )
 
 // ShardIndex tracks Shard instances by ShardID. It provides for acquisition

--- a/consumer/shard_index_test.go
+++ b/consumer/shard_index_test.go
@@ -2,6 +2,9 @@ package consumer
 
 import (
 	gc "github.com/go-check/check"
+
+	"github.com/LiveRamp/gazette/consumer/service"
+	"github.com/LiveRamp/gazette/consumer/service/mocks"
 )
 
 type ShardIndexSuite struct{}
@@ -16,8 +19,8 @@ func (s *ShardIndexSuite) TestRegistration(c *gc.C) {
 }
 
 func (s *ShardIndexSuite) TestAcquireReleaseFlow(c *gc.C) {
-	var shard = new(MockShard)
-	shard.On("ID").Return(ShardID("shard-xyz-000"))
+	var shard = new(mocks.Shard)
+	shard.On("ID").Return(service.ShardID("shard-xyz-000"))
 
 	var ind ShardIndex
 	ind.IndexShard(shard)

--- a/consumer/test_support.go
+++ b/consumer/test_support.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/LiveRamp/gazette/consumer/service"
 	log "github.com/sirupsen/logrus"
 	rocks "github.com/tecbot/gorocksdb"
 
@@ -13,11 +14,6 @@ import (
 	"github.com/LiveRamp/gazette/recoverylog"
 	"github.com/LiveRamp/gazette/topic"
 )
-
-// ConsumerServer is generated from service.proto. This go:generate directive
-// is placed here to avoid relying on the protobuf compiler to propagate it to
-// generated Go source.
-//go:generate mockery -inpkg -name=ConsumerServer
 
 // Test support function. Initializes all shards of |runner| to empty database
 // which begin consumption from the current write-head of each topic journal.
@@ -30,7 +26,7 @@ func ResetShardsToJournalHeads(runner *Runner) error {
 	return nil
 }
 
-func resetShard(runner *Runner, id ShardID, partition topic.Partition) error {
+func resetShard(runner *Runner, id service.ShardID, partition topic.Partition) error {
 	// Determine the write head of the partition Journal.
 	if err := runner.Gazette.Create(partition.Journal); err != nil && err != journal.ErrExists {
 		return err

--- a/consumer/test_support.go
+++ b/consumer/test_support.go
@@ -6,10 +6,10 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/LiveRamp/gazette/consumer/service"
 	log "github.com/sirupsen/logrus"
 	rocks "github.com/tecbot/gorocksdb"
 
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/journal"
 	"github.com/LiveRamp/gazette/recoverylog"
 	"github.com/LiveRamp/gazette/topic"

--- a/examples/word-count/counter/counter.go
+++ b/examples/word-count/counter/counter.go
@@ -5,7 +5,7 @@ package main
 import (
 	"strconv"
 
-	"github.com/LiveRamp/gazette/consumer"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/examples/word-count"
 	"github.com/LiveRamp/gazette/topic"
 )
@@ -20,14 +20,14 @@ type shardCache struct {
 	pendingCounts map[string]int
 }
 
-func (counter) InitShard(s consumer.Shard) error {
+func (counter) InitShard(s service.Shard) error {
 	s.SetCache(&shardCache{
 		pendingCounts: make(map[string]int),
 	})
 	return nil
 }
 
-func (counter) Consume(env topic.Envelope, s consumer.Shard, pub *topic.Publisher) error {
+func (counter) Consume(env topic.Envelope, s service.Shard, pub *topic.Publisher) error {
 	var cache = s.Cache().(*shardCache)
 	var record = env.Message.(*word_count.Record)
 
@@ -47,7 +47,7 @@ func (counter) Consume(env topic.Envelope, s consumer.Shard, pub *topic.Publishe
 	return nil
 }
 
-func (counter) Flush(s consumer.Shard, pub *topic.Publisher) error {
+func (counter) Flush(s service.Shard, pub *topic.Publisher) error {
 	var cache = s.Cache().(*shardCache)
 	var writeBatch = s.Transaction()
 
@@ -64,4 +64,4 @@ func (counter) Flush(s consumer.Shard, pub *topic.Publisher) error {
 }
 
 func main() {} // Not called.
-var Consumer consumer.Consumer = counter{}
+var Consumer service.Consumer = counter{}

--- a/examples/word-count/shuffler/shuffler.go
+++ b/examples/word-count/shuffler/shuffler.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/LiveRamp/gazette/consumer"
+	"github.com/LiveRamp/gazette/consumer/service"
 	"github.com/LiveRamp/gazette/examples/word-count"
 	"github.com/LiveRamp/gazette/topic"
 )
@@ -17,7 +17,7 @@ func (shuffler) Topics() []*topic.Description {
 	return []*topic.Description{word_count.Sentences}
 }
 
-func (shuffler) Consume(env topic.Envelope, s consumer.Shard, pub *topic.Publisher) error {
+func (shuffler) Consume(env topic.Envelope, s service.Shard, pub *topic.Publisher) error {
 	var words = strings.FieldsFunc(env.Message.(*word_count.Sentence).Str,
 		func(r rune) bool { return !unicode.IsLetter(r) })
 
@@ -29,7 +29,7 @@ func (shuffler) Consume(env topic.Envelope, s consumer.Shard, pub *topic.Publish
 	return nil
 }
 
-func (shuffler) Flush(s consumer.Shard, pub *topic.Publisher) error { return nil }
+func (shuffler) Flush(s service.Shard, pub *topic.Publisher) error { return nil }
 
 func main() {} // Not called.
-var Consumer consumer.Consumer = shuffler{}
+var Consumer service.Consumer = shuffler{}

--- a/gazette/client.go
+++ b/gazette/client.go
@@ -15,10 +15,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/LiveRamp/gazette/gazette/client"
 	"github.com/hashicorp/golang-lru"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/LiveRamp/gazette/gazette/client"
 	"github.com/LiveRamp/gazette/journal"
 	"github.com/LiveRamp/gazette/keepalive"
 	"github.com/LiveRamp/gazette/metrics"

--- a/gazette/client.go
+++ b/gazette/client.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/LiveRamp/gazette/gazette/client"
 	"github.com/hashicorp/golang-lru"
 	log "github.com/sirupsen/logrus"
 
@@ -22,8 +23,6 @@ import (
 	"github.com/LiveRamp/gazette/keepalive"
 	"github.com/LiveRamp/gazette/metrics"
 )
-
-//go:generate mockery -inpkg -name=httpClient
 
 const (
 	// By default, all client operations are applied against the default
@@ -36,11 +35,6 @@ const (
 	statsJournalBytes = "bytes"
 	statsJournalHead  = "head"
 )
-
-type httpClient interface {
-	Do(*http.Request) (*http.Response, error)
-	Get(url string) (*http.Response, error)
-}
 
 type requestData struct {
 	Method    string
@@ -74,7 +68,7 @@ type Client struct {
 	requests *currentRequestList
 
 	// Underlying HTTP Client to use for all requests.
-	httpClient httpClient
+	httpClient client.HttpClient
 	// Test support: allow time.Now() to be swapped out.
 	timeNow func() time.Time
 }

--- a/gazette/client/http_client.go
+++ b/gazette/client/http_client.go
@@ -1,0 +1,10 @@
+package client
+
+import "net/http"
+
+//go:generate mockery -name=HttpClient
+
+type HttpClient interface {
+	Do(*http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+}

--- a/gazette/client_test.go
+++ b/gazette/client_test.go
@@ -15,6 +15,7 @@ import (
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/LiveRamp/gazette/gazette/client/mocks"
 	"github.com/LiveRamp/gazette/journal"
 )
 
@@ -69,7 +70,7 @@ func newReadResponseFixture() *http.Response {
 }
 
 func (s *ClientSuite) TestHeadRequestWithInvalidation(c *gc.C) {
-	var mockClient = &mockHttpClient{}
+	var mockClient = &mocks.HttpClient{}
 
 	// Note we use a slightly non-standard fixture of "a/journal/path"
 	// (vs "a/journal") to excercise handling of URL.Path re-writes
@@ -117,7 +118,7 @@ func (s *ClientSuite) TestHeadRequestWithInvalidation(c *gc.C) {
 }
 
 func (s *ClientSuite) TestDirectGet(c *gc.C) {
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 
 	responseFixture := newReadResponseFixture()
 	mockClient.On("Do", mock.MatchedBy(func(request *http.Request) bool {
@@ -141,7 +142,7 @@ func (s *ClientSuite) TestDirectGet(c *gc.C) {
 }
 
 func (s *ClientSuite) TestDirectGetFails(c *gc.C) {
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 
 	mockClient.On("Do", mock.MatchedBy(func(request *http.Request) bool {
 		return request.Method == "GET" &&
@@ -163,7 +164,7 @@ func (s *ClientSuite) TestDirectGetFails(c *gc.C) {
 }
 
 func (s *ClientSuite) TestGetWithoutFragmentLocation(c *gc.C) {
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 
 	responseFixture := newReadResponseFixture()
 	responseFixture.Header.Del(FragmentLocationHeader)
@@ -209,7 +210,7 @@ func (s *ClientSuite) TestGetWithoutFragmentLocation(c *gc.C) {
 }
 
 func (s *ClientSuite) TestGetWithFragmentLocation(c *gc.C) {
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 
 	// Expect an initial HEAD request to the default endpoint.
 	mockClient.On("Do", mock.MatchedBy(func(request *http.Request) bool {
@@ -241,7 +242,7 @@ func (s *ClientSuite) TestGetWithFragmentLocation(c *gc.C) {
 }
 
 func (s *ClientSuite) TestGetWithFragmentLocationFails(c *gc.C) {
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 
 	// Expect an initial HEAD request to the default endpoint.
 	mockClient.On("Do", mock.MatchedBy(func(request *http.Request) bool {
@@ -267,7 +268,7 @@ func (s *ClientSuite) TestGetWithFragmentLocationFails(c *gc.C) {
 }
 
 func (s *ClientSuite) TestGetPersistedErrorCases(c *gc.C) {
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 	s.client.httpClient = mockClient
 
 	location := newURL("http://cloud/location")
@@ -303,7 +304,7 @@ func (s *ClientSuite) TestGetPersistedErrorCases(c *gc.C) {
 }
 
 func (s *ClientSuite) TestCreate(c *gc.C) {
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 
 	// Expect a POST of the journal. Fail with a conflict.
 	mockClient.On("Do", mock.MatchedBy(func(request *http.Request) bool {
@@ -332,7 +333,7 @@ func (s *ClientSuite) TestCreate(c *gc.C) {
 
 func (s *ClientSuite) TestPut(c *gc.C) {
 	content := strings.NewReader("foobar")
-	mockClient := &mockHttpClient{}
+	mockClient := &mocks.HttpClient{}
 
 	// Expect a HEAD request at offset=-1 (not satisfiable) to fill the location cache.
 	// Return an error, and expect it's passed through.
@@ -518,7 +519,7 @@ func (s *ClientSuite) TestDialerIsNonNil(c *gc.C) {
 }
 
 func (s *ClientSuite) TestFragmentBeforeTime(c *gc.C) {
-	var mockClient = new(mockHttpClient)
+	var mockClient = new(mocks.HttpClient)
 	var response = newReadResponseFixture()
 	var baseDate = time.Date(2016, 7, 12, 23, 0, 0, 0, time.UTC)
 
@@ -564,7 +565,7 @@ func (s *ClientSuite) TestFragmentBeforeTimeNoMatch(c *gc.C) {
 	response.Header.Del(FragmentNameHeader)
 	response.Header.Del(FragmentLastModifiedHeader)
 
-	var mockClient = new(mockHttpClient)
+	var mockClient = new(mocks.HttpClient)
 	mockClient.On("Do", mock.MatchedBy(func(request *http.Request) bool {
 		c.Log(request.Method + " " + request.URL.String())
 		return request.Method == "HEAD"
@@ -579,7 +580,7 @@ func (s *ClientSuite) TestFragmentBeforeTimeNoMatch(c *gc.C) {
 }
 
 func (s *ClientSuite) TestFragmentsInRange(c *gc.C) {
-	var mockClient = new(mockHttpClient)
+	var mockClient = new(mocks.HttpClient)
 	var response = newReadResponseFixture()
 
 	mockClient.On("Do", mock.MatchedBy(func(request *http.Request) bool {

--- a/gazette/create_api_test.go
+++ b/gazette/create_api_test.go
@@ -11,17 +11,17 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/LiveRamp/gazette/cloudstore"
-	"github.com/LiveRamp/gazette/consensus"
+	"github.com/LiveRamp/gazette/consensus/mocks"
 )
 
 type CreateAPISuite struct {
-	keys *consensus.MockKeysAPI
+	keys *mocks.KeysAPI
 	cfs  cloudstore.FileSystem
 	mux  *mux.Router
 }
 
 func (s *CreateAPISuite) SetUpTest(c *gc.C) {
-	s.keys = new(consensus.MockKeysAPI)
+	s.keys = new(mocks.KeysAPI)
 	s.mux = mux.NewRouter()
 	s.cfs = cloudstore.NewTmpFileSystem()
 	NewCreateAPI(s.cfs, s.keys, 2).Register(s.mux)
@@ -38,7 +38,7 @@ func (s *CreateAPISuite) TestCreateSuccess(c *gc.C) {
 			PrevExist: etcd.PrevNoExist}).
 		Return(&etcd.Response{Index: 1234}, nil)
 
-	var watcher consensus.MockWatcher
+	var watcher mocks.Watcher
 
 	s.keys.On("Watcher", ServiceRoot+"/items/journal%2Fname",
 		&etcd.WatcherOptions{

--- a/gazette/persister_test.go
+++ b/gazette/persister_test.go
@@ -12,22 +12,23 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/LiveRamp/gazette/cloudstore"
-	"github.com/LiveRamp/gazette/consensus"
+	consensusmocks "github.com/LiveRamp/gazette/consensus/mocks"
 	"github.com/LiveRamp/gazette/journal"
+	journalmocks "github.com/LiveRamp/gazette/journal/mocks"
 )
 
 type PersisterSuite struct {
-	keysAPI   *consensus.MockKeysAPI
+	keysAPI   *consensusmocks.KeysAPI
 	cfs       cloudstore.FileSystem
-	file      *journal.MockFragmentFile
+	file      *journalmocks.FragmentFile
 	fragment  journal.Fragment
 	persister *Persister
 }
 
 func (s *PersisterSuite) SetUpTest(c *gc.C) {
-	s.keysAPI = new(consensus.MockKeysAPI)
+	s.keysAPI = new(consensusmocks.KeysAPI)
 	s.cfs = cloudstore.NewTmpFileSystem()
-	s.file = &journal.MockFragmentFile{}
+	s.file = &journalmocks.FragmentFile{}
 	s.fragment = journal.Fragment{
 		Journal: "a/journal",
 		Begin:   1000,
@@ -173,7 +174,7 @@ func (s *PersisterSuite) TestEmptyFragment(c *gc.C) {
 		Begin:   1000,
 		End:     1000,
 		Sum:     [20]byte{},
-		File:    &journal.MockFragmentFile{},
+		File:    &journalmocks.FragmentFile{},
 	}
 
 	// Intercept and validate the call to os.Remove.

--- a/gazette/write_service_test.go
+++ b/gazette/write_service_test.go
@@ -13,6 +13,7 @@ import (
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/LiveRamp/gazette/gazette/client/mocks"
 	"github.com/LiveRamp/gazette/journal"
 )
 
@@ -98,7 +99,7 @@ func (s *WriteServiceSuite) TestWriteLifecycle(c *gc.C) {
 	writeServiceCoolOffTimeout = time.Millisecond
 	defer func() { writeServiceCoolOffTimeout = actualTimeout }()
 
-	var mockClient mockHttpClient
+	var mockClient mocks.HttpClient
 
 	client, _ := NewClient("http://server")
 	client.httpClient = &mockClient

--- a/journal/interfaces.go
+++ b/journal/interfaces.go
@@ -6,11 +6,11 @@ import (
 	"net/url"
 )
 
-//go:generate mockery -inpkg -name=Doer
-//go:generate mockery -inpkg -name=FragmentFile
-//go:generate mockery -inpkg -name=Getter
-//go:generate mockery -inpkg -name=Header
-//go:generate mockery -inpkg -name=Writer
+//go:generate mockery -name=Doer
+//go:generate mockery -name=FragmentFile
+//go:generate mockery -name=Getter
+//go:generate mockery -name=Header
+//go:generate mockery -name=Writer
 
 // A typed journal name. By convention, journals are named using a forward-
 // slash notation which captures their hierarchical relationships into

--- a/journal/io_test.go
+++ b/journal/io_test.go
@@ -10,6 +10,8 @@ import (
 
 	gc "github.com/go-check/check"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/LiveRamp/gazette/journal/mocks"
 )
 
 type IOSuite struct{}
@@ -74,7 +76,7 @@ func (s *IOSuite) TestReaderRetries(c *gc.C) {
 	}
 
 	var ctx, cancel = context.WithCancel(context.Background())
-	var getter = new(MockGetter)
+	var getter = new(mocks.Getter)
 
 	var rr = NewRetryReaderContext(ctx, Mark{"a/journal", -1}, getter)
 	rr.Blocking = false
@@ -154,7 +156,7 @@ func (s *IOSuite) TestSeeking(c *gc.C) {
 		{strings.NewReader("xyz"), make(closeCh)},
 	}
 
-	var getter = new(MockGetter)
+	var getter = new(mocks.Getter)
 	var ctx = context.Background()
 	var rr = NewRetryReaderContext(ctx, Mark{"a/journal", 0}, getter)
 

--- a/recoverylog/playback_test.go
+++ b/recoverylog/playback_test.go
@@ -13,6 +13,7 @@ import (
 	gc "github.com/go-check/check"
 
 	"github.com/LiveRamp/gazette/journal"
+	"github.com/LiveRamp/gazette/journal/mocks"
 )
 
 type PlaybackSuite struct{}
@@ -20,7 +21,7 @@ type PlaybackSuite struct{}
 func (s *PlaybackSuite) TestPlayerReader(c *gc.C) {
 	var ctx, cancelFn = context.WithCancel(context.Background())
 
-	var getter = new(journal.MockGetter)
+	var getter = new(mocks.Getter)
 	var pr = newPlayerReader(ctx, journal.Mark{Journal: "a/journal", Offset: 100}, getter)
 
 	getter.On("Get", journal.ReadArgs{Journal: "a/journal", Offset: 100, Context: pr.rr.Context}).
@@ -109,7 +110,7 @@ func (r *fixtureReader) Read(p []byte) (n int, err error) {
 func (s *PlaybackSuite) TestReadPrepCases(c *gc.C) {
 	var ctx = context.Background()
 	var mark = journal.Mark{Journal: "a/journal", Offset: 100}
-	var getter = new(journal.MockGetter)
+	var getter = new(mocks.Getter)
 
 	var cases = []struct {
 		offset                  int64

--- a/tool/gazconsumer/main.go
+++ b/tool/gazconsumer/main.go
@@ -242,10 +242,10 @@ func getHeads(itemsRoot *etcd.Response, cdata *consumerData) (map[string]int64, 
 	var writeHeadWg = new(sync.WaitGroup)
 	for _, node := range itemsRoot.Node.Nodes {
 		var route = consensus.NewRoute(itemsRoot, node)
-		var prefix = len(route.Item.Key) + 1
+		var prefix = len(route.Item().Key) + 1
 
 		// Derive journal name from item name.
-		var parts = strings.Split(path.Base(route.Item.Key), "-")
+		var parts = strings.Split(path.Base(route.Item().Key), "-")
 		var journal = fmt.Sprintf("pippio-journals/%s/part-%s",
 			strings.Join(parts[1:len(parts)-1], "-"), parts[len(parts)-1])
 
@@ -253,12 +253,12 @@ func getHeads(itemsRoot *etcd.Response, cdata *consumerData) (map[string]int64, 
 		writeHeadWg.Add(1)
 		go fetchWriteHead(journal, gazetteClient, writeHeadOutput, writeHeadWg)
 
-		if len(route.Entries) == 0 {
+		if len(route.Entries()) == 0 {
 			// Item has no master. This is normal if the consumer is not running.
 			continue
 		}
 
-		for i, member := range route.Entries {
+		for i, member := range route.Entries() {
 			var memberID = member.Key[prefix:]
 			var info, ok = cdata.members[memberID]
 


### PR DESCRIPTION
It is possible to have a race condition when generating multiple mocks
in parallel.

One mockery process may attempt to load a package while another mockery
process is writing to a file in that same package. If the former process
reads the partially written Go file, the load, and subsequently the mock
generation, will fail.

To avoid loading and writing to the same package, this change removes
the "-inpkg" flag so files are written to a "mocks" subpackage. Upon
making this change, there were package tests with import cycles that had
to be addressed. The typical cycle looked like this:

- An interface in package "foo" being mocked references another type
  also defined in "foo". The generated mock has import path "foo/mocks"
  and imports "foo".

- A subject in package "foo" has an accompanying whitebox test also in
  "foo" and using the mock. The test has import path "foo" and imports
  "foo/mocks".

Two tactics were used to break cycles.

- The whitebox test could be converted to a blackbox test use the
  package "foo_test" while its source file did not move. This keeps the
  test near the subject and breaks the cycle.

- The package may have grown too large. Splitting the package such that
  the mocked interfaces and the types it depends on are independent of
  the code that uses them breaks the cycle.

Jira: PUB-4500

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/13)
<!-- Reviewable:end -->
