### PR TITLE
Configure CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and test Gazette
+          command: docker build . -f build/Dockerfile.gazette-build --tag gazette-build
+      - run:
+          name: Build the command image
+          command: docker build . -f build/cmd/Dockerfile.gazette --tag gazette
+      - run:
+          name: Build the examples
+          command: docker build . -f build/examples/Dockerfile.word-count --tag word-count

--- a/build/Dockerfile.gazette-base
+++ b/build/Dockerfile.gazette-base
@@ -1,4 +1,4 @@
-FROM golang:latest AS builder
+FROM golang:1.9.2 AS builder
 
 ENV ROCKSDB_VERSION=5.3.5
 

--- a/build/Dockerfile.gazette-build
+++ b/build/Dockerfile.gazette-build
@@ -1,4 +1,4 @@
-FROM rupertchen/gazette-base:0.1.0 AS builder
+FROM rupertchen/gazette-base:1.0.0 AS builder
 
 ENV DEP_VERSION=v0.3.2
 

--- a/build/Dockerfile.gazette-build
+++ b/build/Dockerfile.gazette-build
@@ -1,4 +1,4 @@
-FROM gazette-base:latest AS builder
+FROM rupertchen/gazette-base:0.1.0 AS builder
 
 ENV DEP_VERSION=v0.3.2
 

--- a/build/Dockerfile.gazette-build
+++ b/build/Dockerfile.gazette-build
@@ -1,4 +1,4 @@
-FROM rupertchen/gazette-base:1.0.0 AS builder
+FROM liveramp/gazette-base:1.0.0 AS builder
 
 ENV DEP_VERSION=v0.3.2
 

--- a/build/README.rst
+++ b/build/README.rst
@@ -3,12 +3,12 @@ Containerized Gazette Build
 
 From the top-level repository directory:
 
-Build a base runtime image with compiled RocksDB libraries and a protobuf
+Pull a base runtime image with compiled RocksDB libraries and a protobuf
 compiler. This image is used both for building gazette itself, and also for
 multi-stage Dockerfiles which pick out compiled binaries of the gazette build
 but still require the RocksDB runtime::
 
-  docker build . -f build/Dockerfile.gazette-base --tag gazette-base
+  docker pull liveramp/gazette-base:0.1.0
 
 Build and test Gazette. This image includes all Gazette source, vendored
 dependencies, compiled packages and binaries, and only completes after
@@ -16,13 +16,43 @@ all tests pass::
 
   docker build . -f build/Dockerfile.gazette-build --tag gazette-build
 
-Create the `gazette` command container, which plucks the `gazette` binary onto
-a `gazette-base` image. Other containerized binaries use a similar pattern::
+Create the ``gazette`` command container, which plucks the ``gazette`` binary
+onto a ``gazette-base`` image. Other containerized binaries use a similar
+pattern::
 
   docker build . -f build/cmd/Dockerfile.gazette --tag gazette
 
-Gazette examples also have Dockerized build targets. Eg, `word-count`
+Gazette examples also have Dockerized build targets. Eg, ``word-count``
 demonstrates building and package consumer plugins, and is utilized by the
-included `word-count` Helm chart::
+included ``word-count`` Helm chart::
 
   docker build . -f build/examples/Dockerfile.word-count --tag word-count
+
+
+Publish The Base Runtime Image
+==============================
+
+Build a new base image::
+
+    docker build . -f build/Dockerfile.gazette-base --tag gazette-base
+
+Test it locally by temporarily changing the references in
+``build/Dockerfile.gazette-build`` and ``build/cmd/Dockerfile.gazette`` from
+``liveramp/gazette-base:X.Y.Z`` to ``gazette-base``. Then run the ``docker
+build`` commands given above.
+
+Once the image has been tested and is ready to publish, pick an appropriate
+version number [*]_ then tag and push the image::
+
+  docker tag gazette-base liveramp/gazette-base:latest
+  docker tag gazette-base liveramp/gazette-base:X.Y.Z
+  docker push liveramp/gazette-base:latest
+  docker push liveramp/gazette-base:X.Y.Z
+
+It may be necessary to log in to Docker Hub before ``docker push``::
+
+  docker login  # Interactively enter username and password
+
+.. [*] For example, changing major versions of Go would be a major version
+       bump, installing an additional tool would be a minor version bump, and
+       fixing a bug in a ``RUN`` command would be a patch version bump.

--- a/build/README.rst
+++ b/build/README.rst
@@ -8,7 +8,7 @@ compiler. This image is used both for building gazette itself, and also for
 multi-stage Dockerfiles which pick out compiled binaries of the gazette build
 but still require the RocksDB runtime::
 
-  docker pull liveramp/gazette-base:0.1.0
+  docker pull liveramp/gazette-base:1.0.0
 
 Build and test Gazette. This image includes all Gazette source, vendored
 dependencies, compiled packages and binaries, and only completes after

--- a/build/README.rst
+++ b/build/README.rst
@@ -38,11 +38,11 @@ Build a new base image::
 
 Test it locally by temporarily changing the references in
 ``build/Dockerfile.gazette-build`` and ``build/cmd/Dockerfile.gazette`` from
-``liveramp/gazette-base:X.Y.Z`` to ``gazette-base``. Then run the ``docker
+``liveramp/gazette-base:X.Y.Z`` [*]_ to ``gazette-base``. Then run the ``docker
 build`` commands given above.
 
 Once the image has been tested and is ready to publish, pick an appropriate
-version number [*]_ then tag and push the image::
+`semantic version number`_ [*]_ then tag and push the image::
 
   docker tag gazette-base liveramp/gazette-base:latest
   docker tag gazette-base liveramp/gazette-base:X.Y.Z
@@ -53,6 +53,10 @@ It may be necessary to log in to Docker Hub before ``docker push``::
 
   docker login  # Interactively enter username and password
 
+.. _semantic version number: https://semver.org
+
+.. [*] Note that this project's convention is to not prefix the version number
+       with "v".
 .. [*] For example, changing major versions of Go would be a major version
        bump, installing an additional tool would be a minor version bump, and
        fixing a bug in a ``RUN`` command would be a patch version bump.

--- a/build/cmd/Dockerfile.gazette
+++ b/build/cmd/Dockerfile.gazette
@@ -1,4 +1,4 @@
 FROM gazette-build:latest AS build
 
-FROM rupertchen/gazette-base:0.1.0
+FROM rupertchen/gazette-base:1.0.0
 COPY --from=build /go/bin/gazette /usr/local/bin

--- a/build/cmd/Dockerfile.gazette
+++ b/build/cmd/Dockerfile.gazette
@@ -1,4 +1,4 @@
 FROM gazette-build:latest AS build
 
-FROM gazette-base:latest
+FROM rupertchen/gazette-base:0.1.0
 COPY --from=build /go/bin/gazette /usr/local/bin

--- a/build/cmd/Dockerfile.gazette
+++ b/build/cmd/Dockerfile.gazette
@@ -1,4 +1,4 @@
 FROM gazette-build:latest AS build
 
-FROM rupertchen/gazette-base:1.0.0
+FROM liveramp/gazette-base:1.0.0
 COPY --from=build /go/bin/gazette /usr/local/bin

--- a/build/examples/Dockerfile.word-count
+++ b/build/examples/Dockerfile.word-count
@@ -8,7 +8,7 @@ RUN go build --buildmode=plugin -o /go/bin/shuffler.so \
 RUN go build --buildmode=plugin -o /go/bin/counter.so \
       github.com/LiveRamp/gazette/examples/word-count/counter
 
-FROM gazette-base:latest
+FROM rupertchen/gazette-base:0.1.0
 COPY --from=build /go/bin/run-consumer /usr/local/bin
 COPY --from=build /go/bin/shuffler.so /usr/local/lib
 COPY --from=build /go/bin/counter.so /usr/local/lib

--- a/build/examples/Dockerfile.word-count
+++ b/build/examples/Dockerfile.word-count
@@ -8,7 +8,7 @@ RUN go build --buildmode=plugin -o /go/bin/shuffler.so \
 RUN go build --buildmode=plugin -o /go/bin/counter.so \
       github.com/LiveRamp/gazette/examples/word-count/counter
 
-FROM rupertchen/gazette-base:1.0.0
+FROM liveramp/gazette-base:1.0.0
 COPY --from=build /go/bin/run-consumer /usr/local/bin
 COPY --from=build /go/bin/shuffler.so /usr/local/lib
 COPY --from=build /go/bin/counter.so /usr/local/lib

--- a/build/examples/Dockerfile.word-count
+++ b/build/examples/Dockerfile.word-count
@@ -8,7 +8,7 @@ RUN go build --buildmode=plugin -o /go/bin/shuffler.so \
 RUN go build --buildmode=plugin -o /go/bin/counter.so \
       github.com/LiveRamp/gazette/examples/word-count/counter
 
-FROM rupertchen/gazette-base:0.1.0
+FROM rupertchen/gazette-base:1.0.0
 COPY --from=build /go/bin/run-consumer /usr/local/bin
 COPY --from=build /go/bin/shuffler.so /usr/local/lib
 COPY --from=build /go/bin/counter.so /usr/local/lib


### PR DESCRIPTION
Use CircleCI 2.0 to test and build the Docker images. This PR is almost
complete, but still references Docker Hub images on "rupertchen" that
must be changed to "liveramp" once they are in place.

Jira: PUB-4350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/17)
<!-- Reviewable:end -->
