### PR TITLE
Make socks server endpoint a flag.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,44 +3,13 @@
 
 [[projects]]
   name = "cloud.google.com/go"
-  packages = [
-    "compute/metadata",
-    "internal",
-    "internal/optional",
-    "storage"
-  ]
+  packages = ["compute/metadata","internal","internal/optional","storage"]
   revision = "8c2dc6124f184bbfc2f13949476cb98e12bda2bb"
   version = "v0.4.0"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = [
-    "aws",
-    "aws/awserr",
-    "aws/awsutil",
-    "aws/client",
-    "aws/client/metadata",
-    "aws/corehandlers",
-    "aws/credentials",
-    "aws/credentials/ec2rolecreds",
-    "aws/credentials/endpointcreds",
-    "aws/credentials/stscreds",
-    "aws/defaults",
-    "aws/ec2metadata",
-    "aws/endpoints",
-    "aws/request",
-    "aws/session",
-    "aws/signer/v4",
-    "internal/shareddefaults",
-    "private/protocol",
-    "private/protocol/query",
-    "private/protocol/query/queryutil",
-    "private/protocol/rest",
-    "private/protocol/restxml",
-    "private/protocol/xml/xmlutil",
-    "service/s3",
-    "service/sts"
-  ]
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/sts"]
   revision = "b9e9981b543687c6fbfd064eaa0f7b69f5fdefd7"
   version = "v1.12.23"
 
@@ -77,23 +46,13 @@
 [[projects]]
   branch = "master"
   name = "github.com/cockroachdb/cockroach"
-  packages = [
-    "util",
-    "util/duration",
-    "util/encoding"
-  ]
+  packages = ["util","util/duration","util/encoding"]
   revision = "0b84c441f9d6f2f6e8f915ea31e8e8978cba63a6"
   source = "https://github.com/jgraettinger/cockroach-encoding.git"
 
 [[projects]]
   name = "github.com/coreos/etcd"
-  packages = [
-    "client",
-    "error",
-    "pkg/pathutil",
-    "pkg/types",
-    "store"
-  ]
+  packages = ["client","error","pkg/pathutil","pkg/types","store"]
   revision = "377f19b0031f9c0aafe2aec28b6f9019311f52f9"
 
 [[projects]]
@@ -122,24 +81,14 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = [
-    "gogoproto",
-    "proto",
-    "protoc-gen-gogo/descriptor"
-  ]
+  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor"]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
   version = "v0.5"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "ptypes",
-    "ptypes/any",
-    "ptypes/duration",
-    "ptypes/timestamp"
-  ]
+  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
@@ -169,10 +118,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru"
-  ]
+  packages = [".","simplelru"]
   revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
 
 [[projects]]
@@ -230,10 +176,7 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = [
-    "prometheus",
-    "prometheus/promhttp"
-  ]
+  packages = ["prometheus","prometheus/promhttp"]
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
@@ -246,27 +189,14 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = [
-    "expfmt",
-    "internal/bitbucket.org/ww/goautoneg",
-    "model"
-  ]
+  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
   revision = "e3fb1a1acd7605367a2b378bc2e2f893c05174b7"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [
-    ".",
-    "xfs"
-  ]
+  packages = [".","xfs"]
   revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/samuel/go-socks"
-  packages = ["socks"]
-  revision = "f6c5f6a06ef657d2b7b1f56a09a01de63381f665"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -288,10 +218,7 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = [
-    "assert",
-    "mock"
-  ]
+  packages = ["assert","mock"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -315,104 +242,42 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = [
-    "curve25519",
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "ssh",
-    "ssh/terminal"
-  ]
+  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
   revision = "687d4b818545e443c8ba223cbef20b1721afd4db"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "context/ctxhttp",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "lex/httplex",
-    "trace"
-  ]
+  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
   revision = "01c190206fbdffa42f334f4b2bf2220f50e64920"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [
-    ".",
-    "google",
-    "internal",
-    "jws",
-    "jwt"
-  ]
+  packages = [".","google","internal","jws","jwt"]
   revision = "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows"
-  ]
+  packages = ["unix","windows"]
   revision = "75813c647272dd855bda156405bf844a5414f5bf"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable"
-  ]
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
   revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
-  packages = [
-    "gensupport",
-    "googleapi",
-    "googleapi/internal/uritemplates",
-    "googleapi/transport",
-    "internal",
-    "iterator",
-    "option",
-    "storage/v1",
-    "transport"
-  ]
+  packages = ["gensupport","googleapi","googleapi/internal/uritemplates","googleapi/transport","internal","iterator","option","storage/v1","transport"]
   revision = "a53f28dc539c26b08a77fc5ae954e02917686ef4"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [
-    ".",
-    "internal",
-    "internal/app_identity",
-    "internal/base",
-    "internal/datastore",
-    "internal/log",
-    "internal/modules",
-    "internal/remote_api",
-    "internal/socket",
-    "internal/urlfetch",
-    "socket",
-    "urlfetch"
-  ]
+  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/socket","internal/urlfetch","socket","urlfetch"]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -424,26 +289,7 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "codes",
-    "connectivity",
-    "credentials",
-    "credentials/oauth",
-    "grpclb/grpc_lb_v1/messages",
-    "grpclog",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
+  packages = [".","balancer","codes","connectivity","credentials","credentials/oauth","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","stats","status","tap","transport"]
   revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
   version = "v1.7.2"
 
@@ -456,6 +302,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1eed9025ff8378ba833e3cd12a8db00ace9dde02330fe1053a9b464a311f2e03"
+  inputs-digest = "843349c6482ec9b0a0c946a25c93949e10227046b36cdf56798518459f44c26d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,10 +75,6 @@
   version = "0.8.0"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/samuel/go-socks"
-
-[[constraint]]
   name = "github.com/satori/go.uuid"
   version = "1.1.0"
 

--- a/cloudstore/sftp_endpoint.go
+++ b/cloudstore/sftp_endpoint.go
@@ -14,7 +14,6 @@ type SFTPEndpoint struct {
 	SFTPUsername  string `json:"username"`
 	SFTPPassword  string `json:"password"`
 	SFTPDirectory string `json:"directory"`
-	SFTPReqProxy  string `json:"req_proxy"`
 	SFTPKey       string `json:"ssh_key"`
 }
 
@@ -52,7 +51,6 @@ func (ep *SFTPEndpoint) properties() Properties {
 		SFTPUsername: ep.SFTPUsername,
 		SFTPPassword: ep.SFTPPassword,
 		SFTPPort:     ep.SFTPPort,
-		SFTPReqProxy: ep.SFTPReqProxy,
 		SFTPKey:      ep.SFTPKey,
 	}
 }

--- a/cloudstore/sftp_fs.go
+++ b/cloudstore/sftp_fs.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/LiveRamp/gazette/envflagfactory"
 	"github.com/pkg/sftp"
 	"github.com/samuel/go-socks/socks"
 	log "github.com/sirupsen/logrus"
@@ -53,8 +52,6 @@ const (
 	SSHErrFileNotFound = 2
 	SSHErrFileExists   = 4
 )
-
-var socksEndpoint = envflagfactory.NewSocksServerServiceEndpoint()
 
 // Luckily sftp.File already meets most of the File interface.
 type sftpFile struct {
@@ -432,7 +429,7 @@ func makeSSHClient(addr string, config *ssh.ClientConfig, reqProxy bool) (*ssh.C
 	var err error
 
 	if reqProxy {
-		var proxy = &socks.Proxy{*socksEndpoint, "", ""}
+		var proxy = &socks.Proxy{socksEndpoint(), "", ""}
 		baseConnection, err = proxy.Dial("tcp", addr)
 	} else {
 		baseConnection, err = net.Dial("tcp", addr)
@@ -454,6 +451,16 @@ func makeSSHClient(addr string, config *ssh.ClientConfig, reqProxy bool) (*ssh.C
 		return nil, err
 	}
 	return ssh.NewClient(conn, newCh, reqCh), nil
+}
+
+func socksEndpoint() string {
+	var socksHost = os.Getenv("SOCKS_SERVER_SERVICE_HOST")
+	var socksPort = os.Getenv("SOCKS_SERVER_SERVICE_PORT")
+	if socksHost == "" || socksPort == "" {
+		return "127.0.0.1:1080"
+	} else {
+		return socksHost + ":" + socksPort
+	}
 }
 
 func isSSHError(err error, sshCode uint32) bool {

--- a/envflagfactory/factory.go
+++ b/envflagfactory/factory.go
@@ -22,14 +22,6 @@ func NewEtcdServiceEndpoint() *string {
 		"Etcd network service host:port.")
 }
 
-// NewSocksServerServiceEndpoint defines the socks server service endpoint flag.
-func NewSocksServerServiceEndpoint() *string {
-	return envflag.CommandLine.ServiceEndpoint(
-		"socks_server",
-		"127.0.0.1:1080",
-		"Socks server network service host:port.")
-}
-
 // NewCloudFSURL defines the cloudFS URL flag.
 func NewCloudFSURL() *string {
 	return envflag.CommandLine.String(

--- a/envflagfactory/factory.go
+++ b/envflagfactory/factory.go
@@ -22,6 +22,14 @@ func NewEtcdServiceEndpoint() *string {
 		"Etcd network service host:port.")
 }
 
+// NewSocksServerServiceEndpoint defines the socks server service endpoint flag.
+func NewSocksServerServiceEndpoint() *string {
+	return envflag.CommandLine.ServiceEndpoint(
+		"socks_server",
+		"127.0.0.1:1080",
+		"Socks server network service host:port.")
+}
+
 // NewCloudFSURL defines the cloudFS URL flag.
 func NewCloudFSURL() *string {
 	return envflag.CommandLine.String(


### PR DESCRIPTION
Previously, the socks server endpoint is discovered from the environment
variables SOCKS_SERVER_SERVICE_HOST and SOCKS_SERVER_SERVICE_PORT.

This change keeps this behavior but also allows the endpoint to be
configured via cli flag.

This change is for making it standard to discover Kubernetes Services using DNS rather than environment variables because we use ExternalName Services for cross-Namespace service discovery and ExternalName Services don't have environment variable support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/18)
<!-- Reviewable:end -->
