### PR TITLE
Add CircleCI status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+|circleci status|
+
+.. |circleci status| image:: https://circleci.com/gh/LiveRamp/gazette.svg?style=svg
+   :target: https://circleci.com/gh/LiveRamp/gazette
+
+
 Gazette
 =======
 


### PR DESCRIPTION
Adding the status badge serves two purposes:

  1. It makes the status of the tests more visible.

  2. It connects the source repository to the CI page.

Jira: PUB-4350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/19)
<!-- Reviewable:end -->
