### PR TITLE
Use Kubernetes Service dns for service discovery.

### DIFF
--- a/envflag/envflag.go
+++ b/envflag/envflag.go
@@ -7,30 +7,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 )
 
 type parseableFromEnv interface {
 	parseFromEnv()
-}
-
-// serviceEndpointFlag holds the metadata for an envflag representing a service
-// endpoint. A service endpoint is a host-port pair.
-type serviceEndpointFlag struct {
-	// host and port are the pair of names of the environment variables.
-	host, port string
-	// ptr is the address of the string variable that stores the value of the
-	// flag. This typically is the return value of a flag.String call.
-	ptr *string
-}
-
-// parseFromEnv implements parseableFromEnv
-func (f serviceEndpointFlag) parseFromEnv() {
-	if h := os.Getenv(f.host); h != "" {
-		if p := os.Getenv(f.port); p != "" {
-			*f.ptr = h + ":" + p
-		}
-	}
 }
 
 // stringFlag holds the metadata for an envflag representing a simple string. A
@@ -61,21 +41,6 @@ type FlagSet struct {
 // NewFlagSet returns a new, empty flag set.
 func NewFlagSet(fs *flag.FlagSet) *FlagSet {
 	return &FlagSet{fs: fs}
-}
-
-// ServiceEndpoint defines a service endpoint flag. A service endpoint is a
-// host-port value, parsed either from a pair of environment variables
-// "<NAME>_HOST", "<NAME>_PORT" or a single colon-delimited
-// command-line argument "-<name>Endpoint". The return value is the address
-// of a string variable that stores the value of the flag.
-func (fs *FlagSet) ServiceEndpoint(name, value, usage string) *string {
-	var prefix = strings.ToUpper(name)
-	var evHost = prefix + "_HOST"
-	var evPort = prefix + "_PORT"
-
-	var ptr = fs.fs.String(name+"Endpoint", value, fmt.Sprintf("%s (%s, %s)", usage, evHost, evPort))
-	fs.addFlag(name, serviceEndpointFlag{evHost, evPort, ptr})
-	return ptr
 }
 
 // String defines a string flag. A string flag is a single string value, parsed

--- a/envflag/envflag.go
+++ b/envflag/envflag.go
@@ -65,13 +65,13 @@ func NewFlagSet(fs *flag.FlagSet) *FlagSet {
 
 // ServiceEndpoint defines a service endpoint flag. A service endpoint is a
 // host-port value, parsed either from a pair of environment variables
-// "<NAME>_SERVICE_HOST", "<NAME>_SERVICE_PORT" or a single colon-delimited
-// command-line argument "-oss<name>Endpoint". The return value is the address
+// "<NAME>_HOST", "<NAME>_PORT" or a single colon-delimited
+// command-line argument "-<name>Endpoint". The return value is the address
 // of a string variable that stores the value of the flag.
 func (fs *FlagSet) ServiceEndpoint(name, value, usage string) *string {
 	var prefix = strings.ToUpper(name)
-	var evHost = prefix + "_SERVICE_HOST"
-	var evPort = prefix + "_SERVICE_PORT"
+	var evHost = prefix + "_HOST"
+	var evPort = prefix + "_PORT"
 
 	var ptr = fs.fs.String(name+"Endpoint", value, fmt.Sprintf("%s (%s, %s)", usage, evHost, evPort))
 	fs.addFlag(name, serviceEndpointFlag{evHost, evPort, ptr})
@@ -80,7 +80,7 @@ func (fs *FlagSet) ServiceEndpoint(name, value, usage string) *string {
 
 // String defines a string flag. A string flag is a single string value, parsed
 // either from an environment variable "<envvarName>" or a command-line
-// argument "-oss<flagName". The return value is the address of a string
+// argument "-<flagName". The return value is the address of a string
 // variable that stores the value of the flag.
 //
 // This is a general flag creation utility which is why flagName and

--- a/envflag/envflag_test.go
+++ b/envflag/envflag_test.go
@@ -17,27 +17,6 @@ type envflagSuite struct {
 
 var _ = check.Suite(&envflagSuite{})
 
-func (s *envflagSuite) TestServiceEndpoint(c *check.C) {
-	var fs = flag.NewFlagSet("TestServiceEndpoint", flag.ContinueOnError)
-	var efs = NewFlagSet(fs)
-	var sut = efs.ServiceEndpoint("dummyName", "default value", "Foo bar baz")
-
-	// Envflags create underlying flags.
-	var actualFlag = fs.Lookup("dummyNameEndpoint")
-	c.Assert(actualFlag, check.NotNil)
-	c.Check(actualFlag.DefValue, check.Equals, "default value")
-	c.Check(actualFlag.Usage, check.Equals, "Foo bar baz (DUMMYNAME_HOST, DUMMYNAME_PORT)")
-
-	// Service endpoint flags parse from a pair of environment variables
-	defer assertAndSetenv(c, "DUMMYNAME_HOST", "dummy.example")()
-	defer assertAndSetenv(c, "DUMMYNAME_PORT", "1234")()
-
-	// Verify pre- and post-Parse values.
-	c.Check(*sut, check.Equals, "default value")
-	efs.Parse()
-	c.Check(*sut, check.Equals, "dummy.example:1234")
-}
-
 func (s *envflagSuite) TestString(c *check.C) {
 	var fs = flag.NewFlagSet("TestString", flag.ContinueOnError)
 	var efs = NewFlagSet(fs)

--- a/envflag/envflag_test.go
+++ b/envflag/envflag_test.go
@@ -26,11 +26,11 @@ func (s *envflagSuite) TestServiceEndpoint(c *check.C) {
 	var actualFlag = fs.Lookup("dummyNameEndpoint")
 	c.Assert(actualFlag, check.NotNil)
 	c.Check(actualFlag.DefValue, check.Equals, "default value")
-	c.Check(actualFlag.Usage, check.Equals, "Foo bar baz (DUMMYNAME_SERVICE_HOST, DUMMYNAME_SERVICE_PORT)")
+	c.Check(actualFlag.Usage, check.Equals, "Foo bar baz (DUMMYNAME_HOST, DUMMYNAME_PORT)")
 
 	// Service endpoint flags parse from a pair of environment variables
-	defer assertAndSetenv(c, "DUMMYNAME_SERVICE_HOST", "dummy.example")()
-	defer assertAndSetenv(c, "DUMMYNAME_SERVICE_PORT", "1234")()
+	defer assertAndSetenv(c, "DUMMYNAME_HOST", "dummy.example")()
+	defer assertAndSetenv(c, "DUMMYNAME_PORT", "1234")()
 
 	// Verify pre- and post-Parse values.
 	c.Check(*sut, check.Equals, "default value")

--- a/envflag/example_test.go
+++ b/envflag/example_test.go
@@ -11,10 +11,10 @@ func Example() {
 	// Define envflags. Because this example is testable, long descriptive
 	// names have been chosen to reduce the chances of an environment variable
 	// by that name actually existing.
-	dbEndpoint := envflag.CommandLine.ServiceEndpoint(
-		"envflagExampleMysql", "mysql.example:3306", "MySQL endpoint")
-	redisEndpoint := envflag.CommandLine.ServiceEndpoint(
-		"envflagExampleRedis", "redis.example:6379", "Redis endpoint")
+	dbEndpoint := envflag.CommandLine.String(
+		"envflagExampleMysql", "MYSQL_SERVICE_ENDPOINT_EXAMPLE", "mysql.example:3306", "MySQL endpoint")
+	redisEndpoint := envflag.CommandLine.String(
+		"envflagExampleRedis", "REDIS_SERVICE_ENDPOINT_EXAMPLE", "redis.example:6379", "Redis endpoint")
 	pingURL := envflag.CommandLine.String(
 		"ping", "ENVFLAG_EXAMPLE_PING_URL", "http://localhost/ping", "URL to ping")
 	user := envflag.CommandLine.String(
@@ -41,22 +41,7 @@ func Example() {
 	// nobody
 }
 
-func ExampleFlagSet_ServiceEndpoint() {
-	// For now, command-line flag names are prefixed with "oss" to avoid
-	// collisions. This will be removed before final release.
-	fs := flag.NewFlagSet("Example", flag.PanicOnError)
-	efs := envflag.NewFlagSet(fs)
-
-	efs.ServiceEndpoint("api", "localhost:80", "API endpoint")
-	fmt.Println(fs.Lookup("apiEndpoint").Name)
-
-	// Output:
-	// apiEndpoint
-}
-
 func ExampleFlagSet_String() {
-	// For now, command-line flag names are prefixed with "oss" to avoid
-	// collisions. This will be removed before final release.
 	fs := flag.NewFlagSet("Example", flag.PanicOnError)
 	efs := envflag.NewFlagSet(fs)
 

--- a/envflagfactory/factory.go
+++ b/envflagfactory/factory.go
@@ -7,18 +7,20 @@ package envflagfactory
 import "github.com/LiveRamp/gazette/envflag"
 
 // NewGazetteServiceEndpoint defines the gazette service endpoint flag.
+// By default, use Kubernetes DNS for service discovery.
 func NewGazetteServiceEndpoint() *string {
 	return envflag.CommandLine.ServiceEndpoint(
 		"gazette",
-		"127.0.0.1:8081",
+		"gazette:8081",
 		"Gazette network service host:port.")
 }
 
 // NewEtcdServiceEndpoint defines the Etcd service endpoint flag.
+// By default, use Kubernetes DNS for service discovery.
 func NewEtcdServiceEndpoint() *string {
 	return envflag.CommandLine.ServiceEndpoint(
 		"etcd",
-		"127.0.0.1:2379",
+		"etcd:2379",
 		"Etcd network service host:port.")
 }
 

--- a/envflagfactory/factory.go
+++ b/envflagfactory/factory.go
@@ -7,22 +7,20 @@ package envflagfactory
 import "github.com/LiveRamp/gazette/envflag"
 
 // NewGazetteServiceEndpoint defines the gazette service endpoint flag.
-// By default, use Kubernetes DNS for service discovery.
 func NewGazetteServiceEndpoint() *string {
 	return envflag.CommandLine.String(
 		"gazette",
 		"GAZETTE_SERVICE_ENDPOINT",
-		"gazette:8081",
+		"gazette.example:8081",
 		"Gazette network service host:port.")
 }
 
 // NewEtcdServiceEndpoint defines the Etcd service endpoint flag.
-// By default, use Kubernetes DNS for service discovery.
 func NewEtcdServiceEndpoint() *string {
 	return envflag.CommandLine.String(
 		"etcd",
 		"ETCD_SERVICE_ENDPOINT",
-		"etcd:2379",
+		"etcd.example:2379",
 		"Etcd network service host:port.")
 }
 

--- a/envflagfactory/factory.go
+++ b/envflagfactory/factory.go
@@ -9,8 +9,9 @@ import "github.com/LiveRamp/gazette/envflag"
 // NewGazetteServiceEndpoint defines the gazette service endpoint flag.
 // By default, use Kubernetes DNS for service discovery.
 func NewGazetteServiceEndpoint() *string {
-	return envflag.CommandLine.ServiceEndpoint(
+	return envflag.CommandLine.String(
 		"gazette",
+		"GAZETTE_SERVICE_ENDPOINT",
 		"gazette:8081",
 		"Gazette network service host:port.")
 }
@@ -18,8 +19,9 @@ func NewGazetteServiceEndpoint() *string {
 // NewEtcdServiceEndpoint defines the Etcd service endpoint flag.
 // By default, use Kubernetes DNS for service discovery.
 func NewEtcdServiceEndpoint() *string {
-	return envflag.CommandLine.ServiceEndpoint(
+	return envflag.CommandLine.String(
 		"etcd",
+		"ETCD_SERVICE_ENDPOINT",
 		"etcd:2379",
 		"Etcd network service host:port.")
 }


### PR DESCRIPTION
Prefer Kubernetes Service dns over env vars for service discovery
because env vars aren't available across Namespaces or for ExternalName
Services, and env vars are required at Pod startup, whereas dns is more
resilient to Endpoint updates.

Remove 127.0.0.1 as the default for discovering etcd and gazette
and expect Kubernetes first. Finally, remove _SERVICE_HOST and
_SERVICE_PORT since this will clobber the dns service discovery in favor
of the env vars, which we don't prefer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/23)
<!-- Reviewable:end -->
