### PR TITLE
gazctl: CLI tool for working with journals, consumers & shards

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -198,6 +198,12 @@
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
+
+[[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   revision = "0b12d6b5"
@@ -328,6 +334,12 @@
   packages = ["."]
   revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
   version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
+  version = "v0.0.1"
 
 [[projects]]
   branch = "master"
@@ -529,6 +541,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "90270dca7289a8a2189f2011e0efd10f03f2c92bb995aec2ca0494b76d878d73"
+  inputs-digest = "a4c79944bc191ae022d035a55e0add3a8b68c373a45667490ad20f400b35a19e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/gazctl/cmd/append.go
+++ b/cmd/gazctl/cmd/append.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/LiveRamp/gazette/pkg/journal"
+)
+
+var appendCmd = &cobra.Command{
+	Use:   "append [journal name] [source-file-one] [source-file-two] ...",
+	Short: "Atomically append content of one or more files to a gazette journal",
+	Long: `Append writes the provided files to a gazette journal. File contents are written in argument
+order, and each file append is atomic (all-or-nothing). When using this command, you should take the time
+to be sure this is actually what you want to do and that the contents of the file are consistent with other
+data in the journal. For example, if a journal contains CSV data, you probably only want to append CSV
+data in the same format. Same for JSON, protobuf, etc.
+
+Example: gazctl append example/journal/name localFileOne localFileTwo
+This appends the contents of localFileOne & Two to example/journal/name.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 2 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+		var name, srcPaths = journal.Name(args[0]), args[1:]
+
+		for _, p := range srcPaths {
+			var file, err = os.Open(p)
+			if err != nil {
+				log.WithFields(log.Fields{"err": err, "path": p}).Fatal("opening file")
+			}
+			userConfirms(fmt.Sprintf("WARNING: Really append %s to %s? This cannot be undone.", p, name))
+
+			if result := gazetteClient().Put(journal.AppendArgs{
+				Journal: name,
+				Content: file,
+			}); result.Error != nil {
+				log.WithFields(log.Fields{"result": result, "path": p}).Fatal("failed to append to journal")
+			} else {
+				log.WithFields(log.Fields{"writeHead": result.WriteHead, "path": p}).Info("file appended to journal")
+			}
+
+			file.Close()
+		}
+	},
+}
+
+func userConfirms(message string) {
+	if defaultYes {
+		return
+	}
+	fmt.Println(message)
+	fmt.Print("Confirm (y/N): ")
+
+	var response string
+	fmt.Scanln(&response)
+
+	for _, opt := range []string{"y", "yes"} {
+		if strings.ToLower(response) == opt {
+			return
+		}
+	}
+	log.Fatal("aborted by user")
+}
+
+var defaultYes bool
+
+func init() {
+	rootCmd.AddCommand(appendCmd)
+
+	appendCmd.Flags().BoolVarP(&defaultYes, "yes", "y", false, "Append without asking for confirmation.")
+}

--- a/cmd/gazctl/cmd/create.go
+++ b/cmd/gazctl/cmd/create.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/LiveRamp/gazette/pkg/journal"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create [journal name] [journal name] ...",
+	Short: "Create new gazette journals",
+	Long: `Create one or more new gazette journals.
+
+Example: gazctl create examples/a-journal/one examples/a-journal/two
+This creates journals examples/a-journal/one & examples/a-journal/two.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+
+		for i := range args {
+			var name = journal.Name(args[i])
+
+			userConfirms(fmt.Sprintf(
+				"WARNING: Really create %s? This cannot be undone.", name.String()))
+
+			if err := gazetteClient().Create(name); err != nil {
+				log.WithField("err", err).Fatal("failed to create journal")
+			} else {
+				log.WithField("name", name).Info("created journal")
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+
+	createCmd.Flags().BoolVarP(&defaultYes, "yes", "y", false, "Create without asking for confirmation.")
+}

--- a/cmd/gazctl/cmd/head.go
+++ b/cmd/gazctl/cmd/head.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/LiveRamp/gazette/pkg/journal"
+)
+
+var headCmd = &cobra.Command{
+	Use:   "head [journal name] [journal name] ...",
+	Short: "Print gazette journal metadata",
+	Long: `Print metadata of a gazette journal, such as its route and current write head, as JSON.
+
+Example: gazctl head examples/a-journal/one examples/a-journal/two`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 1 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+
+		var out = json.NewEncoder(os.Stdout)
+
+		for i := range args {
+			var args = journal.ReadArgs{
+				Journal: journal.Name(args[i]),
+				Offset:  readOffset,
+			}
+
+			var result journal.ReadResult
+			if result, _ = gazetteClient().Head(args); result.Error != nil {
+				log.WithFields(log.Fields{"err": result.Error, "name": args.Journal}).Fatal("failed to HEAD journal")
+			}
+
+			if err := out.Encode(struct {
+				Name   journal.Name
+				Result journal.ReadResult
+			}{args.Journal, result}); err != nil {
+				log.WithFields(log.Fields{"err": err, "name": args.Journal}).Fatal("failed to write HEAD output")
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(headCmd)
+
+	headCmd.Flags().Int64VarP(&readOffset, "offset", "c", 0,
+		"Byte offset to HEAD at, or -1 for the current write-head")
+}

--- a/cmd/gazctl/cmd/read.go
+++ b/cmd/gazctl/cmd/read.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/LiveRamp/gazette/pkg/journal"
+)
+
+var readCmd = &cobra.Command{
+	Use:   "read [journal name]",
+	Short: "Read the contents of a gazette journal",
+	Long: `Read and output the contents of a gazette journal.
+Reads may be blocking / tailing (--block) and may begin from any non-zero
+offset (--offset), or -1 (which reads from the current journal head).
+
+Example: gazctl cat examples/a-journal
+This reads journal content from byte-offset zero, through to the current write head.
+
+Example: gazctl cat examples/a-journal --offset 1234 --block 1m
+This reads journal content from byte-offset 1234, and blocks one minute to read
+new content as it is appended.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+
+		var mark = journal.Mark{
+			Journal: journal.Name(args[0]),
+			Offset:  readOffset,
+		}
+
+		var ctx = context.Background()
+		if readTimeout != 0 {
+			ctx, _ = context.WithTimeout(ctx, readTimeout)
+		}
+
+		var reader = journal.NewRetryReaderContext(ctx, mark, gazetteClient())
+		reader.Blocking = (readTimeout != 0)
+
+		var br = bufio.NewReader(reader)
+		if _, err := br.Peek(1); err == nil {
+			log.WithFields(log.Fields{"mark": reader.AdjustedMark(br)}).Info("reading from mark")
+		}
+		if _, err := io.Copy(os.Stdout, br); err != nil && err != journal.ErrNotYetAvailable {
+			log.WithField("err", err).Fatal("failed to read journal data")
+		}
+	},
+}
+
+var (
+	readOffset  int64
+	readTimeout time.Duration
+)
+
+func init() {
+	rootCmd.AddCommand(readCmd)
+
+	readCmd.Flags().Int64VarP(&readOffset, "offset", "c", 0,
+		"Byte offset to begin reading from, or -1 for the current write-head")
+	readCmd.Flags().DurationVarP(&readTimeout, "block", "t", 0,
+		"Total duration to block for, reading ongoing journal appends. Zero (default) does not block")
+}

--- a/cmd/gazctl/cmd/root.go
+++ b/cmd/gazctl/cmd/root.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"plugin"
+	"strings"
+
+	etcd "github.com/coreos/etcd/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/LiveRamp/gazette/pkg/consumer"
+	"github.com/LiveRamp/gazette/pkg/gazette"
+)
+
+var configFile string
+
+// Execute evaluates provided arguments against the rootCmd hierarchy.
+// This is called by main.main().
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+	if lazyWriteService != nil {
+		lazyWriteService.Stop()
+	}
+}
+
+// rootCmd parents all other commands in the hierarchy.
+var rootCmd = &cobra.Command{
+	Use:   "gazctl",
+	Short: "gazctl is a command-line interface for interacting with gazette",
+}
+
+func init() {
+	log.SetOutput(os.Stderr)
+
+	cobra.OnInitialize(initConfig)
+	flag.Parse()
+
+	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "f", "",
+		"config file (default is $HOME/.gazctl.yaml)")
+
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if configFile != "" {
+		viper.SetConfigFile(configFile)
+	}
+
+	viper.SetConfigName(".gazctl")
+	viper.AddConfigPath("$HOME")
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		log.WithField("file", viper.ConfigFileUsed()).Info("read config")
+	}
+
+	// Allow environment variables to override file configuration.
+	// Treat variable underscores as nested-path specifiers.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+}
+
+func etcdClient() etcd.Client {
+	if lazyEtcdClient == nil {
+		var ep = viper.GetString("etcd.endpoint")
+		if ep == "" {
+			log.Fatal("etcd.endpoint not provided")
+		}
+
+		var err error
+		lazyEtcdClient, err = etcd.New(etcd.Config{Endpoints: []string{ep}})
+		if err != nil {
+			log.WithField("err", err).Fatal("building etcd client")
+		}
+	}
+	return lazyEtcdClient
+}
+
+func gazetteClient() *gazette.Client {
+	if lazyGazetteClient == nil {
+		var ep = viper.GetString("gazette.endpoint")
+		if ep == "" {
+			log.Fatal("gazette.endpoint not provided")
+		}
+
+		var err error
+		lazyGazetteClient, err = gazette.NewClient(ep)
+		if err != nil {
+			log.WithField("err", err).Fatal("building gazette client")
+		}
+	}
+	return lazyGazetteClient
+}
+
+func consumerPlugin() consumer.Consumer {
+	if lazyConsumerPlugin == nil {
+		var path = viper.GetString("consumer.plugin")
+		if path == "" {
+			return nil
+		}
+
+		var module, err = plugin.Open(path)
+		if err != nil {
+			log.WithFields(log.Fields{"path": path, "err": err}).Fatal("failed to open plugin module")
+		}
+
+		if i, err := module.Lookup("Consumer"); err != nil {
+			log.WithField("err", err).Fatal("failed to lookup Consumer symbol")
+		} else if c, ok := i.(*consumer.Consumer); !ok {
+			log.WithField("instance", i).Fatalf("symbol `Consumer` is not a consumer.Consumer: %#v", i)
+		} else {
+			lazyConsumerPlugin = *c
+		}
+	}
+	return lazyConsumerPlugin
+}
+
+func writeService() *gazette.WriteService {
+	if lazyWriteService == nil {
+		lazyWriteService = gazette.NewWriteService(gazetteClient())
+		lazyWriteService.Start()
+	}
+	return lazyWriteService
+}
+
+var (
+	lazyGazetteClient  *gazette.Client
+	lazyEtcdClient     etcd.Client
+	lazyWriteService   *gazette.WriteService
+	lazyConsumerPlugin consumer.Consumer
+)

--- a/cmd/gazctl/cmd/shard_compose.go
+++ b/cmd/gazctl/cmd/shard_compose.go
@@ -1,0 +1,412 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	rocks "github.com/tecbot/gorocksdb"
+
+	"github.com/LiveRamp/gazette/pkg/consumer"
+	"github.com/LiveRamp/gazette/pkg/journal"
+	"github.com/LiveRamp/gazette/pkg/recoverylog"
+)
+
+var shardComposeCmd = &cobra.Command{
+	Use:   "compose [input-path-one] [input-path-two] ... [output-path]",
+	Short: "Combine zero or more sorted input sources into a new RocksDB.",
+	Long: `Compose enumerates provided input sources (each either a path to a
+RocksDB, or a sorted flat file of encoded keys/values in the standard
+"ldb dump / scan --hex" format), optionally applies a provided plugin filter,
+and builds a new RocksDB holding the resulting key/value set.
+
+If two or more sources provide the same key, the key from the source appearing
+first in the argument list has precedence, and values of other sources are
+dropped (In the future, we may update this tool to incorporate an optional
+merge operator).
+
+Optional "--consumer-offset" and "--consumer-journal" flags are provided to help
+with a special-but-common case, where one desires to update the check-pointed
+consumer offset of a shard. If specified, compose will upsert a key/value of
+the specified offset checkpoint, with precedence over all other sources.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 || (consumerOffset != 0 && consumerJournal == "") {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+		var srcPaths, tgtPath = args[:len(args)-1], args[len(args)-1]
+
+		var opts = rocks.NewDefaultOptions()
+		if plugin := consumerPlugin(); plugin != nil {
+			if initer, _ := plugin.(consumer.OptionsIniter); initer != nil {
+				initer.InitOptions(opts)
+			}
+		}
+
+		// Build iterators for all input sequences.
+		var iterFuncs []iterFunc
+
+		// A specified --consumer-offset has highest precedence.
+		if consumerJournal != "" {
+			iterFuncs = append(iterFuncs,
+				newConsumerOffsetIterFunc(journal.Name(consumerJournal), consumerOffset))
+		}
+
+		// Followed by arguments in argument order.
+		for _, p := range srcPaths {
+			var fn iterFunc
+			var err error
+
+			if _, err = os.Stat(path.Join(p, "CURRENT")); err == nil {
+				var db *rocks.DB
+				if db, err = rocks.OpenDbForReadOnly(opts, p, true); err == nil {
+					fn = newDBIterFunc(db)
+				}
+			} else {
+				var fin *os.File
+				if fin, err = os.Open(p); err == nil {
+					fn = newHexIterFunc(bufio.NewReader(fin))
+				}
+			}
+
+			if err != nil {
+				log.WithFields(log.Fields{"path": p, "err": err}).Fatal("failed to open input source")
+			}
+			iterFuncs = append(iterFuncs, fn)
+		}
+
+		// Combine into a single sorted sequence via a heap iterator.
+		var iterFunc = newHeapIterFunc(iterFuncs...)
+
+		// Optionally wrap with a filtering iterator.
+		if plugin := consumerPlugin(); plugin != nil {
+			if filterer, ok := plugin.(consumer.Filterer); ok {
+				iterFunc = newFilterIterFunc(filterer, iterFunc)
+			}
+		}
+
+		var fsm *recoverylog.FSM
+		var err error
+
+		if composeRecoveryLog != "" {
+			fsm, err = recoverylog.NewFSM(recoverylog.FSMHints{Log: journal.Name(composeRecoveryLog)})
+			if err != nil {
+				log.WithField("err", err).Fatal("NewFSM failed")
+			}
+			author, err := recoverylog.NewRandomAuthorID()
+			if err != nil {
+				log.WithField("err", err).Fatal("NewRandomAuthorID failed")
+			}
+
+			var recorder = recoverylog.NewRecorder(fsm, author, len(tgtPath), writeService())
+			opts.SetEnv(rocks.NewObservedEnv(recorder))
+		}
+
+		opts.SetCreateIfMissing(true)
+		opts.SetErrorIfExists(true)
+		opts.PrepareForBulkLoad()
+		// Disable any configured compaction filter, as it will prevent trivial
+		// file moves during the final manual compaction step and isn't applied
+		// on L0 writes anyway.
+		opts.SetCompactionFilter(nil)
+
+		tgtDB, err := rocks.OpenDb(opts, tgtPath)
+		if err != nil {
+			log.WithField("err", err).Fatal("failed to open target database")
+		}
+
+		var wb = rocks.NewWriteBatch()
+		var wo = rocks.NewDefaultWriteOptions()
+		wo.SetSync(false)
+		wo.DisableWAL(true)
+
+		// Consume keys & values from the iterator.
+		key, value, err := iterFunc(nil, nil)
+		for count := 0; err == nil; key, value, err = iterFunc(key, value) {
+			wb.Put(key, value)
+
+			if count++; count%writeBatchSize == 0 {
+				tgtDB.Write(wo, wb)
+				wb.Clear()
+			}
+		}
+		if err != io.EOF {
+			log.WithField("err", err).Fatal("failed to compose DB")
+		}
+
+		// Flush final records and memtables.
+		tgtDB.Write(wo, wb)
+		if err = tgtDB.Flush(rocks.NewDefaultFlushOptions()); err != nil {
+			log.WithField("err", err).Fatal("failed to Flush")
+		}
+
+		// Manually compact |trgDB|, which (due to the earlier PrepareForBulkLoad)
+		// has generated only L0 SST files. Fortunately, because we enumerated
+		// |srcDB| in sorted order such that SSTs are non-overlapping, compaction
+		// is achieved by trivially moving existing files to lower LSM tree levels.
+		tgtDB.CompactRange(rocks.Range{})
+		tgtDB.Close()
+
+		if fsm != nil {
+			var tgtHintsPath = path.Join(tgtPath, "fsm_hints.json")
+
+			var tgtHints, err = os.Create(tgtHintsPath)
+			if err != nil {
+				log.WithField("err", err).Fatal("failed to create fsm_hints.json")
+			}
+			defer tgtHints.Close()
+
+			if err = json.NewEncoder(tgtHints).Encode(fsm.BuildHints()); err != nil {
+				log.WithField("err", err).Fatal("failed to Marshal FSMHints")
+			}
+			log.WithField("path", tgtHintsPath).Info("wrote hints")
+		}
+	},
+}
+
+// newHexIterFunc returns an iterFunc which parses sequential "hex-encoded-key hex-encoded-value\n"
+// records from the bufio.Reader. A variety of field delineations are supported (eg, " : " & " ==> ",
+// both formats produced by the "ldb dump" / "ldb scan" tool).
+func newHexIterFunc(br *bufio.Reader) iterFunc {
+	var readHex = func(b []byte, delim byte) ([]byte, error) {
+		var t, err = br.Peek(2)
+		if err != nil {
+			return nil, err
+		} else if t[0] != '0' && t[1] != 'x' {
+			return nil, fmt.Errorf("invalid hex prefix (expected '0x'): %v", t)
+		}
+		br.Discard(2)
+
+		b = b[:0]
+		for done := false; !done; {
+			var t, err = br.ReadSlice(delim)
+
+			if err == nil {
+				t = t[:len(t)-1] // Trim |delim|.
+				done = true
+			} else if err == io.EOF {
+				return nil, io.ErrUnexpectedEOF
+			} else if err != bufio.ErrBufferFull {
+				return nil, err
+			}
+
+			_, err = hex.Decode(t, t)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, t[:len(t)/2]...)
+		}
+		return b, nil
+	}
+
+	return func(prevKey, prevValue []byte) (key, value []byte, err error) {
+		if key, err = readHex(prevKey, ' '); err != nil {
+			return
+		}
+		// Skip past field separator bytes to the hex value.
+		for done := false; !done; {
+			var t byte
+
+			if t, err = br.ReadByte(); err != nil {
+				if err == io.EOF {
+					err = io.ErrUnexpectedEOF
+				}
+				return
+			}
+
+			switch t {
+			case ' ', ':', '=', '>': // Pass.
+			default:
+				br.UnreadByte()
+				done = true
+			}
+		}
+
+		value, err = readHex(prevValue, '\n')
+		return
+	}
+}
+
+// newDBIterFunc returns an iterFunc which walks the database in ascending sorted order.
+func newDBIterFunc(db *rocks.DB) iterFunc {
+	var ro = rocks.NewDefaultReadOptions()
+	ro.SetFillCache(false)
+
+	var it = db.NewIterator(ro)
+	it.SeekToFirst()
+
+	return func(prevKey, prevValue []byte) (key, value []byte, err error) {
+		if !it.Valid() {
+			if err = it.Err(); err == nil {
+				err = io.EOF
+			}
+
+			it.Close()
+			ro.Destroy()
+			return
+		}
+
+		// We must copy because |it| owns it's Key()/Value() memory.
+		key = append(prevKey[:0], it.Key().Data()...)
+		value = append(prevValue[:0], it.Value().Data()...)
+		it.Next()
+
+		return
+	}
+}
+
+// newFilterIterFunc returns an iterFunc which applies a consumer.Filterer to another iterFunc.
+func newFilterIterFunc(filter consumer.Filterer, fn iterFunc) iterFunc {
+	return func(prevKey, prevValue []byte) (key, value []byte, err error) {
+		for {
+			if key, value, err = fn(prevKey, prevValue); err != nil {
+				return
+			}
+
+			if remove, newVal := filter.Filter(0, key, value); remove {
+				continue
+			} else if newVal != nil {
+				value = newVal
+			}
+			return
+		}
+	}
+}
+
+// newConsumerOffsetIterFunc returns an iterFunc which returns a single key, representing
+// the encoded consumer offset checkpoint of journal |name| at |offset|.
+func newConsumerOffsetIterFunc(name journal.Name, offset int64) iterFunc {
+	var offsetKey = consumer.AppendOffsetKeyEncoding(nil, name)
+	var offsetValue = consumer.AppendOffsetValueEncoding(nil, offset)
+
+	return func(prevKey, prevValue []byte) (key, value []byte, err error) {
+		if offsetKey == nil {
+			err = io.EOF
+			return
+		}
+		key = append(prevKey[:0], offsetKey...)
+		value = append(prevValue[:0], offsetValue...)
+		offsetKey = nil
+		return
+	}
+}
+
+// newHeapIterFunc returns an iterFunc which merges multiple other iterFuncs,
+// each of which must be in ascending sorted order, and producing a single
+// sorted output. Where keys collide, the value of the first iterFunc appearing
+// in the argument list is used, and others are dropped.
+func newHeapIterFunc(iterFuncs ...iterFunc) iterFunc {
+	var iters iterHeap
+
+	for i, fn := range iterFuncs {
+		var key, value, err = fn(nil, nil)
+
+		heap.Push(&iters, iter{
+			fn:         fn,
+			key:        key,
+			precedence: i,
+			value:      value,
+			err:        err,
+		})
+	}
+
+	return func(prevKey, prevValue []byte) (key, value []byte, err error) {
+		for len(iters) != 0 {
+			var it = heap.Pop(&iters).(iter)
+
+			if it.err == io.EOF {
+				continue
+			} else if it.err != nil {
+				err = it.err
+				return
+			}
+
+			var c = bytes.Compare(prevKey, it.key)
+			if c > 0 {
+				err = fmt.Errorf("invalid iterator order: %x > %x", prevKey, it.key)
+				return
+			}
+
+			key = append(prevKey[:0], it.key...)
+			value = append(prevValue[:0], it.value...)
+
+			it.key, it.value, it.err = it.fn(it.key, it.value)
+			heap.Push(&iters, it)
+
+			if c < 0 {
+				return
+			}
+
+			// Else c == 0, meaning we've already returned a higher-precedence value
+			// for this key. Continue to swallow this key/value.
+		}
+		err = io.EOF
+		return
+	}
+}
+
+type iterFunc func(prevKey, prevValue []byte) (key, value []byte, err error)
+
+type iter struct {
+	fn         iterFunc
+	precedence int
+	key, value []byte
+	err        error
+}
+
+type iterHeap []iter
+
+func (h iterHeap) Len() int      { return len(h) }
+func (h iterHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+// Order on error, then key, then precedence; eg, pop errors first.
+func (h iterHeap) Less(i, j int) bool {
+	if h[j].err != nil {
+		return false
+	} else if h[i].err != nil {
+		return true
+	}
+
+	if c := bytes.Compare(h[i].key, h[j].key); c != 0 {
+		return c < 0
+	}
+	return h[i].precedence < h[j].precedence
+}
+
+func (h *iterHeap) Push(x interface{}) { *h = append(*h, x.(iter)) }
+
+func (h *iterHeap) Pop() interface{} {
+	var old = *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+var (
+	composeRecoveryLog string
+	consumerJournal    string
+	consumerOffset     int64
+)
+
+const writeBatchSize = 200
+
+func init() {
+	shardCmd.AddCommand(shardComposeCmd)
+
+	shardComposeCmd.Flags().StringVarP(&composeRecoveryLog, "recovery-log", "r", "",
+		"Recovery log in which to record the composed shard. By default, no recording is done.")
+	shardComposeCmd.Flags().StringVarP(&consumerJournal, "consumer-journal", "j", "",
+		"Journal for which to update the check-pointed consumption offset. By default, the offset is not modified.")
+	shardComposeCmd.Flags().Int64VarP(&consumerOffset, "consumer-offset", "o", 0,
+		"Byte offset for which to update the check-pointed consumption offset. --consumer-journal must be set if this is.")
+}

--- a/cmd/gazctl/cmd/shard_compose_test.go
+++ b/cmd/gazctl/cmd/shard_compose_test.go
@@ -1,0 +1,299 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/LiveRamp/gazette/pkg/consumer"
+	gc "github.com/go-check/check"
+
+	"github.com/LiveRamp/gazette/pkg/consumer/consumertest"
+)
+
+// Use a small buffer to exercise bufio.Reader underflow & fill.
+const bufferSize = 16
+
+type ShardComposeSuite struct{}
+
+func (s *ShardComposeSuite) TestHexCases(c *gc.C) {
+	var cases = []iterFuncTestCase{
+		{ // Valid input. We handle keys/value lengths that exceed the bufio.Reader's internal capacity.
+			fn: hexIter("" +
+				"0x : 0x00\n" +
+				"0xaabbccdd ==> 0x11\n" +
+				"0xbbccddee ==> 0x2222\n" +
+				"0xCCCC : 0x333333\n" +
+				"0x" + strings.Repeat("d", 4*bufferSize) + " : 0x" + strings.Repeat("4", 5*bufferSize) + "\n" +
+				"0xeEeeff => : 0x\n"),
+			expectKeys: [][]byte{
+				nil,
+				{0xaa, 0xbb, 0xcc, 0xdd},
+				{0xbb, 0xcc, 0xdd, 0xee},
+				{0xcc, 0xcc},
+				bytes.Repeat([]byte{0xdd}, 4*bufferSize/2),
+				{0xee, 0xee, 0xff},
+			},
+			expectVals: [][]byte{
+				{0x00},
+				{0x11},
+				{0x22, 0x22},
+				{0x33, 0x33, 0x33},
+				bytes.Repeat([]byte{0x44}, 5*bufferSize/2),
+				{},
+			},
+		},
+		{ // Simple, valid example.
+			fn:         hexIter("0xaaaaaa 0xbbbbbb\n"),
+			expectKeys: [][]byte{{0xaa, 0xaa, 0xaa}},
+			expectVals: [][]byte{{0xbb, 0xbb, 0xbb}},
+		},
+		{ // Key missing 0x prefix.
+			fn:        hexIter("aaaaaa 0xbbbbbb\n"),
+			expectErr: "invalid hex prefix .*",
+		},
+		{ // Value missing 0x prefix.
+			fn:        hexIter("0xaaaaaa bbbbbb\n"),
+			expectErr: "invalid hex prefix .*",
+		},
+		{ // Missing value.
+			fn:        hexIter("0xaaaaaa\n"),
+			expectErr: "unexpected EOF",
+		},
+		{ // Missing trailing newline.
+			fn:        hexIter("0xaaaaaa 0xbbbbbb"),
+			expectErr: "unexpected EOF",
+		},
+		{ // Invalid key hex.
+			fn:        hexIter("0xaaxxaaaa 0xbbbbbb\n"),
+			expectErr: "encoding/hex: .*",
+		},
+		{ // Invalid value hex.
+			fn:        hexIter("0xaaxxaa 0xbbxxbbbb\n"),
+			expectErr: "encoding/hex: .*",
+		},
+		{ // Extra token.
+			fn:        hexIter("0xaa 0xbb 0xcc\n"),
+			expectErr: "encoding/hex: .*",
+		},
+	}
+
+	for _, tc := range cases {
+		tc.test(c)
+	}
+}
+
+func (s *ShardComposeSuite) TestHeapCases(c *gc.C) {
+	var cases = []iterFuncTestCase{
+		{ // Simple, valid example.
+			fn: newHeapIterFunc(hexIter("" +
+				"0xaaaaaa 0xbbbbbb\n" +
+				"0xcccc 0xdddd\n" +
+				"0xee 0xff\n")),
+			expectKeys: [][]byte{{0xaa, 0xaa, 0xaa}, {0xcc, 0xcc}, {0xee}},
+			expectVals: [][]byte{{0xbb, 0xbb, 0xbb}, {0xdd, 0xdd}, {0xff}},
+		},
+		{ // Reversing ordering results in an error on the out-of-order key.
+			fn: newHeapIterFunc(hexIter("" +
+				"0xcccc 0xdddd\n" +
+				"0xee 0xff\n" +
+				"0xaaaaaa 0xbbbbbb\n")),
+			expectKeys: [][]byte{{0xcc, 0xcc}, {0xee}},
+			expectVals: [][]byte{{0xdd, 0xdd}, {0xff}},
+			expectErr:  "invalid iterator order: ee > aaaaaa",
+		},
+		{ // Composing iterators. Where keys collide, expect all but the first iterator value is dropped.
+			fn: newHeapIterFunc(
+				hexIter(""+
+					"0xaabb 0x2222\n"+
+					"0xbbcc 0x3333\n"),
+				hexIter(""+
+					"0xaaaa 0x1111\n"+
+					"0xbbcc 0xfff2\n"+ // Discarded.
+					"0xeeff 0x4444\n"),
+				hexIter(""+
+					"0xbbcc 0xfff3\n"+ // Discarded.
+					"0xeeff 0xfff4\n"+ // Discarded.
+					"0xffff 0x5555\n"),
+			),
+			expectKeys: [][]byte{{0xaa, 0xaa}, {0xaa, 0xbb}, {0xbb, 0xcc}, {0xee, 0xff}, {0xff, 0xff}},
+			expectVals: [][]byte{{0x11, 0x11}, {0x22, 0x22}, {0x33, 0x33}, {0x44, 0x44}, {0x55, 0x55}},
+		},
+		{ // Underlying iterator errors are surfaced when encountered.
+			fn: newHeapIterFunc(
+				hexIter(""+
+					"0xaabb 0x2222\n"+
+					"0xfoobar bad value\n"),
+				hexIter(""+
+					"0xaaaa 0x1111\n"+
+					"0xeeff 0x4444\n"),
+			),
+			expectKeys: [][]byte{{0xaa, 0xaa}, {0xaa, 0xbb}},
+			expectVals: [][]byte{{0x11, 0x11}, {0x22, 0x22}},
+			expectErr:  "encoding/hex: .*",
+		},
+	}
+
+	for _, tc := range cases {
+		tc.test(c)
+	}
+}
+
+func (s *ShardComposeSuite) TestDBIterCases(c *gc.C) {
+	var shard, err = consumertest.NewShard("shard-compose-suite")
+	c.Assert(err, gc.IsNil)
+
+	defer shard.Close()
+
+	c.Assert(shard.Database().Put(shard.WriteOptions(), []byte{0xbb, 0xbb}, []byte{0x22, 0x22}), gc.IsNil)
+	c.Assert(shard.Database().Put(shard.WriteOptions(), []byte{0xaa, 0xaa}, []byte{0x11, 0x11}), gc.IsNil)
+
+	var cases = []iterFuncTestCase{
+		{ // Direct iteration of a DB.
+			fn:         newDBIterFunc(shard.Database()),
+			expectKeys: [][]byte{{0xaa, 0xaa}, {0xbb, 0xbb}},
+			expectVals: [][]byte{{0x11, 0x11}, {0x22, 0x22}},
+		},
+		{ // DB iterator wrapped with heap iterator.
+			fn:         newHeapIterFunc(newDBIterFunc(shard.Database())),
+			expectKeys: [][]byte{{0xaa, 0xaa}, {0xbb, 0xbb}},
+			expectVals: [][]byte{{0x11, 0x11}, {0x22, 0x22}},
+		},
+		{ // DB iterator composed with hex iterator.
+			fn: newHeapIterFunc(
+				newDBIterFunc(shard.Database()),
+				hexIter(""+
+					"0xaaaa 0xffff\n"+ // Discarded.
+					"0xaabb 0x1122\n")),
+			expectKeys: [][]byte{{0xaa, 0xaa}, {0xaa, 0xbb}, {0xbb, 0xbb}},
+			expectVals: [][]byte{{0x11, 0x11}, {0x11, 0x22}, {0x22, 0x22}},
+		},
+	}
+	for _, tc := range cases {
+		tc.test(c)
+	}
+}
+
+func (s *ShardComposeSuite) TestFilterCases(c *gc.C) {
+	// |filter| modifies keys with 0xee suffix, and removes keys with 0xff suffix.
+	var filter = testFilter{
+		fn: func(key, value []byte) (remove bool, newValue []byte) {
+			if t := key[len(key)-1]; t == 0xee {
+				newValue = []byte{0x00}
+			} else if t == 0xff {
+				remove = true
+			}
+			return
+		},
+	}
+
+	var cases = []iterFuncTestCase{
+		{ // Passed through.
+			fn:         newFilterIterFunc(filter, hexIter("0xaaaa 0xbbbb\n")),
+			expectKeys: [][]byte{{0xaa, 0xaa}},
+			expectVals: [][]byte{{0xbb, 0xbb}},
+		},
+		{ // Modified.
+			fn:         newFilterIterFunc(filter, hexIter("0xaaee 0xbbbb\n")),
+			expectKeys: [][]byte{{0xaa, 0xee}},
+			expectVals: [][]byte{{0x00}},
+		},
+		{ // Filtered.
+			fn:         newFilterIterFunc(filter, hexIter("0xaaff 0xbbbb\n")),
+			expectKeys: [][]byte{},
+			expectVals: [][]byte{},
+		},
+		{ // Multiple filtered keys.
+			fn: newFilterIterFunc(filter, hexIter(""+
+				"0xaaff 0xbbbb\n"+ // Filtered.
+				"0xbbff 0xcccc\n"+ // Filtered.
+				"0xddff 0xdddd\n"+ // Filtered.
+				"0xeeee 0xeeee\n"+ // Modified.
+				"0xffaa 0xffff\n")), // Passed through.
+			expectKeys: [][]byte{{0xee, 0xee}, {0xff, 0xaa}},
+			expectVals: [][]byte{{0x00}, {0xff, 0xff}},
+		},
+	}
+	for _, tc := range cases {
+		tc.test(c)
+	}
+}
+
+func (s *ShardComposeSuite) TestOffsetUpdateCases(c *gc.C) {
+	var fixture = consumer.AppendOffsetKeyEncoding(nil, "foo/bar")
+	c.Check(fixture, gc.DeepEquals,
+		[]byte{0x0, 0x12, 'm', 'a', 'r', 'k', 0x0, 0x1, 0x12, 'f', 'o', 'o', '/', 'b', 'a', 'r', 0x0, 0x1})
+
+	var cases = []iterFuncTestCase{
+		{
+			fn:         newConsumerOffsetIterFunc("foo/bar", 12345),
+			expectKeys: [][]byte{fixture},
+			expectVals: [][]byte{{0xf7, 0x30, 0x39}},
+		},
+		{ // Mix a consumer offset into another sequence.
+			fn: newHeapIterFunc(
+				newConsumerOffsetIterFunc("foo/bar", 12345),
+				hexIter(""+
+					"0x0001 0xaaaa\n"+
+					"0xcccc 0xdddd\n")),
+			expectKeys: [][]byte{{0x0, 0x1}, fixture, {0xcc, 0xcc}},
+			expectVals: [][]byte{{0xaa, 0xaa}, {0xf7, 0x30, 0x39}, {0xdd, 0xdd}},
+		},
+		{ // newHeapIterFunc ensures the consumer offset has precedence over a prior value.
+			fn: newHeapIterFunc(
+				newConsumerOffsetIterFunc("foo/bar", 12345),
+				hexIter(""+
+					"0x"+hex.EncodeToString(fixture)+" 0xaaaa\n"+
+					"0xcccc 0xdddd\n")),
+			expectKeys: [][]byte{fixture, {0xcc, 0xcc}},
+			expectVals: [][]byte{{0xf7, 0x30, 0x39}, {0xdd, 0xdd}},
+		},
+	}
+	for _, tc := range cases {
+		tc.test(c)
+	}
+}
+
+type testFilter struct {
+	fn func(key, value []byte) (remove bool, newValue []byte)
+}
+
+func (tf testFilter) Filter(level int, key, value []byte) (bool, []byte) { return tf.fn(key, value) }
+
+func hexIter(s string) iterFunc {
+	return newHexIterFunc(bufio.NewReaderSize(bytes.NewReader([]byte(s)), bufferSize))
+}
+
+type iterFuncTestCase struct {
+	fn         iterFunc
+	expectErr  string
+	expectKeys [][]byte
+	expectVals [][]byte
+}
+
+func (tc iterFuncTestCase) test(c *gc.C) {
+	var key, value []byte
+	var err error
+
+	for i := range tc.expectKeys {
+		key, value, err = tc.fn(key, value)
+		c.Check(err, gc.IsNil)
+		c.Check(key, gc.DeepEquals, tc.expectKeys[i])
+		c.Check(value, gc.DeepEquals, tc.expectVals[i])
+	}
+
+	key, value, err = tc.fn(key, value)
+
+	if tc.expectErr != "" {
+		c.Check(err, gc.ErrorMatches, tc.expectErr)
+	} else {
+		c.Check(err, gc.Equals, io.EOF)
+	}
+}
+
+var _ = gc.Suite(&ShardComposeSuite{})
+
+func Test(t *testing.T) { gc.TestingT(t) }

--- a/cmd/gazctl/cmd/shard_metadata.go
+++ b/cmd/gazctl/cmd/shard_metadata.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/LiveRamp/gazette/pkg/consumer"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	rocks "github.com/tecbot/gorocksdb"
+)
+
+var shardMetadata = &cobra.Command{
+	Use:   "metadata [local-db-path]",
+	Short: "Print metadata about a recovered consumer shard.",
+	Long: `Metadata prints metadata about a recovered shard database, such as estimated
+keys, live vs total data, consumer offsets, and level statistics.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+		var dbPath = args[0]
+
+		var opts = rocks.NewDefaultOptions()
+		if plugin := consumerPlugin(); plugin != nil {
+			if initer, _ := plugin.(consumer.OptionsIniter); initer != nil {
+				initer.InitOptions(opts)
+			}
+		}
+
+		var db, err = rocks.OpenDbForReadOnly(opts, dbPath, true)
+		if err != nil {
+			log.WithFields(log.Fields{"path": dbPath, "err": err}).Fatal("failed to open RocksDB")
+		}
+		defer db.Close()
+
+		var ro = rocks.NewDefaultReadOptions()
+		ro.SetFillCache(false)
+		defer ro.Destroy()
+
+		offsets, err := consumer.LoadOffsetsFromDB(db, ro)
+		if err != nil {
+			log.WithFields(log.Fields{"path": dbPath, "err": err}).Fatal("failed to load consumer offsets")
+		}
+
+		fmt.Printf("Consumer Offsets:    %v\n", offsets)
+		fmt.Printf("Estimated Keys:      %s\n", db.GetProperty("rocksdb.estimate-num-keys"))
+		fmt.Printf("Total Data:          %s\n", db.GetProperty("rocksdb.total-sst-files-size"))
+		fmt.Printf("Estimated Live Data: %s\n", db.GetProperty("rocksdb.estimate-live-data-size"))
+		fmt.Printf("\nLevel Stats:\n%s\n", db.GetProperty("rocksdb.levelstats"))
+	},
+}
+
+func init() {
+	shardCmd.AddCommand(shardMetadata)
+}

--- a/cmd/gazctl/cmd/shard_recover.go
+++ b/cmd/gazctl/cmd/shard_recover.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+
+	etcd "github.com/coreos/etcd/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/LiveRamp/gazette/pkg/gazette"
+	"github.com/LiveRamp/gazette/pkg/recoverylog"
+)
+
+var shardCmd = &cobra.Command{
+	Use:   "shard",
+	Short: "Commands for working with a gazette consumer shard",
+}
+
+var shardRecoverCmd = &cobra.Command{
+	Use:   "recover [etcd-hints-path] [local-output-path]",
+	Short: "Recover contents of the indicated log hints.",
+	Long: `Recover replays the recoverylog indicated by the argument Etcd hints
+path into a local output directory, and additionally writes recovered JSON hints
+upon completion.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 2 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+		var hintsPath, tgtPath = args[0], args[1]
+
+		var hintsResp, err = etcd.NewKeysAPI(etcdClient()).Get(context.Background(), hintsPath, nil)
+		if err != nil {
+			log.WithField("err", err).Fatal("failed to read hints from Etcd")
+		}
+
+		var hints recoverylog.FSMHints
+		if err = json.Unmarshal([]byte(hintsResp.Node.Value), &hints); err != nil {
+			log.WithFields(log.Fields{"err": err, "resp": *hintsResp}).
+				Fatal("failed to unmarshal hints")
+		}
+
+		player, err := recoverylog.NewPlayer(hints, tgtPath)
+		if err != nil {
+			log.WithField("err", err).Fatal("preparing playback")
+		}
+
+		go func() {
+			if err := player.PlayContext(
+				context.Background(),
+				struct {
+					*gazette.Client
+					*gazette.WriteService
+				}{gazetteClient(), writeService()},
+			); err != nil {
+				log.WithField("err", err).Fatal("shard playback failed")
+			}
+		}()
+
+		var fsm = player.FinishAtWriteHead()
+		if fsm == nil {
+			return
+		}
+
+		// Write recovered hints under |tgtPath|.
+		var recoveredPath = path.Join(tgtPath, path.Base(hintsPath)+".recoveredHints.json")
+
+		fout, err := os.Create(recoveredPath)
+		if err == nil {
+			err = json.NewEncoder(fout).Encode(fsm.BuildHints())
+		}
+		if err != nil {
+			log.WithFields(log.Fields{"err": err, "path": recoveredPath}).Fatal("failed to write recovered hints")
+		} else {
+			log.WithField("path", recoveredPath).Info("wrote recovered hints")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(shardCmd)
+
+	shardCmd.AddCommand(shardRecoverCmd)
+}

--- a/cmd/gazctl/cmd/shard_routes.go
+++ b/cmd/gazctl/cmd/shard_routes.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/gogo/protobuf/proto"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/LiveRamp/gazette/pkg/consumer"
+)
+
+var shardRoutes = &cobra.Command{
+	Use:   "routes [http://grpc-endpoint:grpc-port]",
+	Short: "Prints current routes of the running consumer.",
+	Long:  `Routes queries a consumer supporting the Consumer GRPC API and prints current routing metadata.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+
+		var cc, err = consumer.NewClient(args[0])
+		if err != nil {
+			log.WithField("err", err).Fatal("failed to create consumer client")
+		}
+
+		var state = cc.State()
+		if err := proto.MarshalText(os.Stdout, &state); err != nil {
+			log.WithField("err", err).Fatal("failed to encode consumer state")
+		}
+	},
+}
+
+func init() {
+	shardCmd.AddCommand(shardRoutes)
+}

--- a/cmd/gazctl/main.go
+++ b/cmd/gazctl/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/LiveRamp/gazette/cmd/gazctl/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/run-consumer/main.go
+++ b/cmd/run-consumer/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net"
 	"os"
 	"path"
 	"plugin"
@@ -34,10 +33,6 @@ type Config struct {
 	Etcd    struct{ Endpoint string } // Etcd endpoint to use.
 	Gazette struct{ Endpoint string } // Gazette endpoint to use.
 }
-
-type HostPort struct{ Host, Port string }
-
-func (hp HostPort) Addr() string { return net.JoinHostPort(hp.Host, hp.Port) }
 
 func (cfg Config) Validate() error {
 	if !path.IsAbs(cfg.Service.AllocatorRoot) {

--- a/pkg/consumer/interfaces.go
+++ b/pkg/consumer/interfaces.go
@@ -68,6 +68,13 @@ type Consumer interface {
 	Flush(Shard, *topic.Publisher) error
 }
 
+// Optional Consumer interface for implementations which prune or expire
+// keys & values from the Shard database on a Consumer-specific criteria.
+// This interface intentionally overlaps with `rocks.CompactionFilter`.
+type Filterer interface {
+	Filter(level int, key, val []byte) (remove bool, newVal []byte)
+}
+
 // Optional Consumer interface for notification of Shard initialization prior
 // to an initial Consume. A common use case is to initialize the shard cache.
 type ShardIniter interface {

--- a/pkg/consumer/routines_test.go
+++ b/pkg/consumer/routines_test.go
@@ -107,6 +107,15 @@ func (s *RoutinesSuite) TestStoreOffsetsToEtcd(c *gc.C) {
 	s.keysAPI.AssertExpectations(c)
 }
 
+func (s *RoutinesSuite) TestOffsetKeyValueRegression(c *gc.C) {
+	var key = AppendOffsetKeyEncoding([]byte{0xff, 0xff}, "bar/baz")
+	c.Check(key, gc.DeepEquals, []byte{0xff, 0xff, 0x00, 0x12, 'm', 'a', 'r', 'k',
+		0x0, 0x1, 0x12, 'b', 'a', 'r', '/', 'b', 'a', 'z', 0x00, 0x1})
+
+	var value = AppendOffsetValueEncoding([]byte{0xff, 0xff}, 123456)
+	c.Check(value, gc.DeepEquals, []byte{0xff, 0xff, 0xf8, 0x1, 0xe2, 0x40})
+}
+
 func (s *RoutinesSuite) TestLoadAndStoreOffsetsToDB(c *gc.C) {
 	path, err := ioutil.TempDir("", "routines-suite")
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
gazctl is an experimental CLI interface for interacting with Gazette.
It uses spf13's Cobra for help messages, command discovery, and
documentation. Viper is similarly used for configuration management.

Current commands support:
 * Creating, reading from, and writing to journals.
 * Recovering shard DBs to local disk from hints.
 * Printing metadata about a recovered shard, including consumer
   offsets.
 * Composing new shard DBs from files & other database, updating
   consumer offsets, and optionally recording into a recovery-log.
 * Quering a consumer supporting the GRPC API and printing current
   routes.

Tested:
  * Unit coverage for shard-compose iterators.
  * Manual testing of commands against local cluster / `stream-sum` example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/35)
<!-- Reviewable:end -->
