### PR TITLE
Identify and prune obsolete log fragments

### DIFF
--- a/cmd/gazctl/cmd/append.go
+++ b/cmd/gazctl/cmd/append.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -49,26 +48,6 @@ This appends the contents of localFileOne & Two to example/journal/name.`,
 		}
 	},
 }
-
-func userConfirms(message string) {
-	if defaultYes {
-		return
-	}
-	fmt.Println(message)
-	fmt.Print("Confirm (y/N): ")
-
-	var response string
-	fmt.Scanln(&response)
-
-	for _, opt := range []string{"y", "yes"} {
-		if strings.ToLower(response) == opt {
-			return
-		}
-	}
-	log.Fatal("aborted by user")
-}
-
-var defaultYes bool
 
 func init() {
 	rootCmd.AddCommand(appendCmd)

--- a/cmd/gazctl/cmd/shard_prune_log.go
+++ b/cmd/gazctl/cmd/shard_prune_log.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/LiveRamp/gazette/pkg/journal"
+)
+
+var shardPruneLogCmd = &cobra.Command{
+	Use:   "prune-log [etcd-hints-path]",
+	Short: "Prune log removes fragments of a hinted recovery log which are no longer needed",
+	Long: `
+Recovery logs capture every write which has ever occurred in a Shard DB.
+This includes all prior writes of client keys & values, and also RocksDB
+compactions, which can significantly inflate the total volume of writes
+relative to the data currently represented in a RocksDB.
+
+Prune log examines the provided hints to identify Fragments of the log
+which have no intersection with any live files of the DB, and can thus
+be safely deleted.
+
+It is recommended to run this tool against the ".lastRecovered" hints
+written by consumers after recovering & becoming primary for a shard.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+		if dryRun {
+			log.Info("Running in dry-run mode. Pass -dry-run=false to disable")
+		}
+
+		var hints = loadHints(args[0])
+
+		var _, segments, err = hints.LiveLogSegments()
+		if err != nil {
+			log.WithField("err", err).Fatal("failed to determine live log segments")
+		} else if len(segments) == 0 {
+			log.WithField("hints", hints).Fatal("hints include no live log segments")
+		}
+
+		// Zero the LastOffset of the final hinted Segment. This has the effect of implicitly
+		// intersecting all subsequent fragments (having offsets greater than its FirstOffset).
+		// We want this behavior because playback will continue to read offsets & Fragments
+		// after reading past the final hinted Segment.
+		segments[len(segments)-1].LastOffset = 0
+
+		var deleteCh = make(chan journal.Fragment)
+		var wg sync.WaitGroup
+
+		if !dryRun {
+			userConfirms(fmt.Sprintf("WARNING: Really prune fragments of %s? This cannot be undone.", hints.Log))
+
+			for i := 0; i != concurrentDeletes; i++ {
+				wg.Add(1)
+
+				go func() {
+					defer wg.Done()
+
+					for f := range deleteCh {
+						if err := cloudFS().Remove(f.ContentPath()); err != nil {
+							log.WithFields(log.Fields{"err": err, "path": f.ContentPath()}).Warn("failed to delete fragment")
+						}
+					}
+				}()
+			}
+		}
+
+		var nTotal, nPruned, bytesTotal, bytesPruned int64
+
+		if err = cloudFS().Walk(hints.Log.String(), journal.NewWalkFuncAdapter(func(f journal.Fragment) error {
+			nTotal += 1
+			bytesTotal += f.Size()
+
+			if len(segments.Intersect(f.Begin, f.End)) == 0 {
+				log.WithFields(log.Fields{
+					"log":  f.Journal,
+					"name": f.ContentName(),
+					"size": f.Size(),
+					"mod":  f.RemoteModTime,
+				}).Warn("pruning fragment")
+
+				nPruned += 1
+				bytesPruned += f.Size()
+
+				if !dryRun {
+					deleteCh <- f
+				}
+			}
+			return nil
+		})); err != nil {
+			log.WithFields(log.Fields{"err": err, "log": hints.Log}).Fatal("failed to walk directory")
+		}
+
+		close(deleteCh)
+		wg.Wait()
+
+		log.WithFields(log.Fields{
+			"log":         hints.Log,
+			"nTotal":      nTotal,
+			"nPruned":     nPruned,
+			"nLive":       nTotal - nPruned,
+			"bytesTotal":  bytesTotal,
+			"bytesPruned": bytesPruned,
+			"bytesLive":   bytesTotal - bytesPruned,
+		}).Info("finished pruning log")
+	},
+}
+
+const concurrentDeletes = 10
+
+var dryRun bool
+
+func init() {
+	shardCmd.AddCommand(shardPruneLogCmd)
+
+	shardPruneLogCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", true,
+		"Perform a dry-run (don't actually delete fragments)")
+	shardPruneLogCmd.Flags().BoolVarP(&defaultYes, "yes", "y", false,
+		"Append without asking for confirmation.")
+}

--- a/pkg/recoverylog/recorded_op.pb.go
+++ b/pkg/recoverylog/recorded_op.pb.go
@@ -46,7 +46,7 @@ type RecordedOp struct {
 	// Previous FSM checksum to which this operation should be applied (eg, the
 	// expected checksum arrived at after applying the previous operation.
 	Checksum uint32 `protobuf:"fixed32,2,opt,name=checksum,proto3" json:"checksum,omitempty"`
-	// Author is the unique ID of the Recorder which write this RecordedOp.
+	// Author is the unique ID of the Recorder which wrote this RecordedOp.
 	// Each Recorder randomly generates an Author ID at startup, and thereafter
 	// applies it to all operations it records.
 	Author Author `protobuf:"fixed32,3,opt,name=author,proto3,casttype=Author" json:"author,omitempty"`
@@ -277,7 +277,7 @@ type Segment struct {
 	FirstOffset int64 `protobuf:"varint,3,opt,name=first_offset,json=firstOffset,proto3" json:"first_offset,omitempty"`
 	// Checksum of the RecordedOp having |first_seq_no|.
 	FirstChecksum uint32 `protobuf:"fixed32,4,opt,name=first_checksum,json=firstChecksum,proto3" json:"first_checksum,omitempty"`
-	// Last (highest) sequence number of RecordedOps within this Segment.
+	// Last (highest, inclusive) sequence number of RecordedOps within this Segment.
 	LastSeqNo int64 `protobuf:"varint,5,opt,name=last_seq_no,json=lastSeqNo,proto3" json:"last_seq_no,omitempty"`
 	// Last offset (exclusive) of the Segment. Zero means the offset is not known
 	// (eg, because the Segment was produced by a Recorder).

--- a/pkg/recoverylog/recorded_op.proto
+++ b/pkg/recoverylog/recorded_op.proto
@@ -129,7 +129,7 @@ message Segment {
   int64 first_offset = 3;
   // Checksum of the RecordedOp having |first_seq_no|.
   fixed32 first_checksum = 4;
-  // Last (highest) sequence number of RecordedOps within this Segment.
+  // Last (highest, inclusive) sequence number of RecordedOps within this Segment.
   int64 last_seq_no = 5;
   // Last offset (exclusive) of the Segment. Zero means the offset is not known
   // (eg, because the Segment was produced by a Recorder).

--- a/pkg/recoverylog/segment.go
+++ b/pkg/recoverylog/segment.go
@@ -2,79 +2,73 @@ package recoverylog
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 )
+
+// Validate returns an error if the Segment is inconsistent.
+func (s Segment) Validate() error {
+	if s.Author == 0 {
+		return errors.New("segment.Author is zero")
+	} else if s.FirstSeqNo <= 0 {
+		return errors.New("segment.FirstSeqNo <= 0")
+	} else if s.FirstOffset < 0 {
+		return errors.New("segment.FirstOffset < 0")
+	} else if s.LastSeqNo < s.FirstSeqNo {
+		return errors.New("segment.LastSeqNo < segment.FirstSeqNo")
+	} else if s.LastOffset != 0 && s.LastOffset <= s.FirstOffset {
+		return errors.New("segment.LastOffset <= segment.FirstOffset")
+	}
+	return nil
+}
 
 // SegmentSet is a collection of Segment with the following invariants:
 //  * Entries have strictly increasing SeqNo, and are non-overlapping
 //    (s[i].LastSeqNo < s[i+1].SeqNo; note this implies a single author
 //     for any covered SeqNo).
-//  * Entries have monotonicly increasing Offset.
+//  * Entries have monotonically increasing FirstOffset.
+//  * Entries have monotonically increasing LastOffset, however a strict
+//    suffix of entries are permitted to have a LastOffset of zero (implied
+//    infinite LastOffset).
 type SegmentSet []Segment
 
-// Adds a Segment to this SegmentSet. An error is returned
+// Add a Segment to this SegmentSet. An error is returned
 // if |segment| would result in an inconsistent SegmentSet.
 func (s *SegmentSet) Add(segment Segment) error {
-	if segment.LastSeqNo < segment.FirstSeqNo {
-		return errors.New("segment.LastSeqNo < segment.FirstSeqNo")
+	if err := segment.Validate(); err != nil {
+		return err
 	}
 
 	// Find the insertion range [begin, end) of |segment|.
-	begin := sort.Search(len(*s), func(i int) bool {
+	var begin = sort.Search(len(*s), func(i int) bool {
 		return (*s)[i].FirstSeqNo >= segment.FirstSeqNo
 	})
-	// If |segment| overlaps with the previous Segment, merge left. The SegmentSet
-	// invariant ensures there can be at most one such merge (FirstSeqNo is
+	// Attempt to reduce |segment| with the previous Segment. The SegmentSet
+	// invariant ensures there can be at most one such reduction (FirstSeqNo is
 	// strictly increasing).
 	if begin > 0 {
-		prev := (*s)[begin-1]
-
-		if prev.FirstOffset > segment.FirstOffset {
-			// FirstOffset should be monotonically increasing.
-			return errors.New("FirstOffset is not monotonically increasing")
-		}
-
-		if prev.Author != segment.Author {
-			if prev.LastSeqNo >= segment.FirstSeqNo {
-				// Overlapping Segments should have the same Author.
-				return errors.New("overlapping Segment Authors differ")
-			}
-		} else if prev.LastSeqNo+1 >= segment.FirstSeqNo {
-			// Adjacent or overlapping Segments with same Author.
-			// Left-merge |segment| to cover |prev|.
-			segment.FirstSeqNo = prev.FirstSeqNo
-			segment.FirstOffset = prev.FirstOffset
-			segment.FirstChecksum = prev.FirstChecksum
-			begin--
+		if s, err := reduceSegment((*s)[begin-1], segment); err == nil {
+			segment, begin = s, begin-1
+		} else if err == errNotReducible {
+			// Pass.
+		} else {
+			return err
 		}
 	}
-
-	// While |segment| overlaps with next Segment(s), merge-right.
-	end := begin
+	// Perform iterative reductions of |segment| with following Segments of the set.
+	var end = begin
 	for ; end != len(*s); end++ {
-		next := (*s)[end]
-
-		if next.FirstOffset < segment.FirstOffset {
-			// FirstOffset should be monotonically increasing.
-			return errors.New("FirstOffset is not monotonically increasing")
-		}
-
-		if next.Author != segment.Author {
-			if next.FirstSeqNo <= segment.LastSeqNo {
-				// Overlapping Segments should have the same Author.
-				return errors.New("overlapping Segment Authors differ")
-			}
-		} else if next.FirstSeqNo <= segment.LastSeqNo+1 {
-			// Adjacent or overlapping Segments with same Author.
-			// Right-merge |segment| to cover |next|.
-			if next.LastSeqNo > segment.LastSeqNo {
-				segment.LastSeqNo = next.LastSeqNo
-			}
+		if s, err := reduceSegment((*s)[end], segment); err == nil {
+			segment = s
 			continue
+		} else if err == errNotReducible {
+			break
+		} else {
+			return err
 		}
-		break
 	}
 
+	// Splice |segment| into the SegmentSet, replacing |begin| to |end| (exclusive).
 	if begin == len(*s) {
 		*s = append(*s, segment)
 	} else {
@@ -83,3 +77,83 @@ func (s *SegmentSet) Add(segment Segment) error {
 	}
 	return nil
 }
+
+// reduceSegment returns a single Segment which is the reduction of |a| and |b|,
+// an error indicating a data-model inconsistency, or errNotReducible if a
+// reduction cannot be performed.
+func reduceSegment(a, b Segment) (Segment, error) {
+	// Establish invariants:
+	//  * a.FirstSeqNo <= b.FirstSeqNo.
+	//  * If FirstSeqNo's are equal, than a.LastSeqNo >= b.LastSeqNo.
+	//
+	// This leaves the remaining possible cases:
+	//
+	//  Overlap:            Covered:         Disjoint:
+	//   |---- a ----|       |---- a ----|    |-- a --|
+	//      |---- b ----|      |-- b --|                |-- b --|
+	//
+	//  Equal-right:        Equal-left:
+	//   |---- a ----|       |---- a ----|
+	//      |-- b ---|       |-- b ---|
+	//
+	//  Identity:           Adjacent:
+	//   |---- a ----|       |-- a --|
+	//   |---- b ----|                |-- b --|
+	if a.FirstSeqNo > b.FirstSeqNo ||
+		a.FirstSeqNo == b.FirstSeqNo && a.LastSeqNo < b.LastSeqNo {
+		a, b = b, a
+	}
+
+	switch {
+
+	// Offset ordering constraint checks.
+	case a.FirstSeqNo < b.FirstSeqNo && a.FirstOffset > b.FirstOffset:
+		return a, fmt.Errorf("expected monotonic FirstOffset: %#v vs %#v", a, b)
+	case a.FirstSeqNo < b.FirstSeqNo && a.LastOffset == 0 && b.LastOffset != 0:
+		return a, fmt.Errorf("expected preceding Segment to also include LastOffset: %#v vs %#v", a, b)
+
+	case a.LastSeqNo <= b.LastSeqNo && nonZeroAndLess(b.LastOffset, a.LastOffset):
+		fallthrough
+	case a.LastSeqNo >= b.LastSeqNo && nonZeroAndLess(a.LastOffset, b.LastOffset):
+		return a, fmt.Errorf("expected monotonic LastOffset: %#v vs %#v", a, b)
+
+	// Checksum constraint check.
+	case a.FirstSeqNo == b.FirstSeqNo && a.FirstChecksum != b.FirstChecksum:
+		return a, fmt.Errorf("expected FirstChecksum equality: %#v vs %#v", a, b)
+
+	// Cases where we cannot reduce further:
+	case a.LastSeqNo+1 < b.FirstSeqNo: // Disjoint.
+		return a, errNotReducible
+	case a.LastSeqNo+1 == b.FirstSeqNo && a.Author != b.Author: // Adjacent, but of different authors.
+		return a, errNotReducible
+
+	// Remaining cases have overlap, and therefor must have been written by the same Author.
+	case a.Author != b.Author:
+		return a, fmt.Errorf("expected Segment Author equality: %#v vs %#v", a, b)
+
+	case a.FirstSeqNo <= b.FirstSeqNo:
+		// FirstOffset is a lower-bound. Prefer the tighter bound.
+		if a.FirstSeqNo == b.FirstSeqNo && a.FirstOffset < b.FirstOffset {
+			a.FirstOffset = b.FirstOffset
+		}
+		// LastOffset is optional. Prefer that it be set. Note we've verified monotonicity already.
+		if a.LastSeqNo == b.LastSeqNo && a.LastOffset == 0 {
+			a.LastOffset = b.LastOffset
+		}
+		// Extend |a| in the Overlap & Adjacent cases.
+		if a.LastSeqNo < b.LastSeqNo {
+			a.LastSeqNo, a.LastOffset = b.LastSeqNo, b.LastOffset
+		}
+		return a, nil
+
+	default:
+		panic("not reached")
+	}
+}
+
+// nonZeroAndLess returns whether |a| is non-zero and less-than |b|.
+func nonZeroAndLess(a, b int64) bool {
+	return a != 0 && a < b
+}
+
+var errNotReducible = errors.New("not reducible")

--- a/pkg/recoverylog/segment_test.go
+++ b/pkg/recoverylog/segment_test.go
@@ -15,88 +15,231 @@ func (s *SegmentSuite) SetUpTest(c *gc.C) {
 	rand.Seed(seed)
 }
 
-func (s *SegmentSuite) TestModelIdentity(c *gc.C) {
+func (s *SegmentSuite) TestSegmentValidationCases(c *gc.C) {
+	var seg, model = Segment{}, Segment{
+		Author:        0xfefe,
+		FirstSeqNo:    10,
+		FirstChecksum: 0xabab,
+		FirstOffset:   0,
+		LastSeqNo:     10,
+		LastOffset:    1,
+	}
+
+	for _, tc := range []struct {
+		fn  func()
+		err string
+	}{
+		{func() { seg.Author = 0 }, "segment.Author is zero"},
+		{func() { seg.FirstSeqNo = 0 }, "segment.FirstSeqNo <= 0"},
+		{func() { seg.FirstSeqNo = -1 }, "segment.FirstSeqNo <= 0"},
+		{func() { seg.FirstOffset = -1 }, "segment.FirstOffset < 0"},
+		{func() { seg.LastSeqNo = 9 }, "segment.LastSeqNo < segment.FirstSeqNo"},
+		{func() { seg.FirstOffset, seg.LastOffset = 100, 99 }, "segment.LastOffset <= segment.FirstOffset"},
+	} {
+		c.Check(model.Validate(), gc.IsNil)
+
+		seg = model
+		tc.fn()
+		c.Check(seg.Validate(), gc.ErrorMatches, tc.err)
+	}
+
+	// LastOffset may also be zero.
+	model.LastOffset = 0
+	c.Check(model.Validate(), gc.IsNil)
+}
+
+func (s *SegmentSuite) TestSegmentReductionCases(c *gc.C) {
+	for _, tc := range []struct {
+		a, b, e Segment
+		err     string
+	}{
+		// Overlap.
+		{
+			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 700, FirstChecksum: 0x22},
+			b: Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 9, FirstOffset: 400, LastOffset: 901, FirstChecksum: 0x44},
+			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 200, LastOffset: 901, FirstChecksum: 0x22},
+		},
+		// Overlap, non-monotonic FirstOffset.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 9, FirstOffset: 100, LastOffset: 901, FirstChecksum: 0x44},
+			err: "expected monotonic FirstOffset: .*",
+		},
+		// Overlap, non-monotonic LastOffset.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 9, FirstOffset: 400, LastOffset: 700, FirstChecksum: 0x44},
+			err: "expected monotonic LastOffset: .*",
+		},
+		// Overlap, and preceding Segment is missing LastOffset.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 000, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 9, FirstOffset: 400, LastOffset: 901, FirstChecksum: 0x44},
+			err: "expected preceding Segment to also include LastOffset: .*",
+		},
+		// Overlap, mismatched authors.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x2, FirstSeqNo: 4, LastSeqNo: 9, FirstOffset: 400, LastOffset: 901, FirstChecksum: 0x44},
+			err: "expected Segment Author equality: .*",
+		},
+		// Covered.
+		{
+			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b: Segment{Author: 0x1, FirstSeqNo: 3, LastSeqNo: 6, FirstOffset: 300, LastOffset: 000, FirstChecksum: 0x33},
+			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+		},
+		// Disjoint.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 4, FirstOffset: 200, LastOffset: 401, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x1, FirstSeqNo: 6, LastSeqNo: 7, FirstOffset: 600, FirstChecksum: 0x66},
+			err: errNotReducible.Error(),
+		},
+		// Equal-right (note non-zero LastOffset is preferred).
+		{
+			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b: Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 7, FirstOffset: 400, LastOffset: 000, FirstChecksum: 0x44},
+			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+		},
+		// Equal-right, but non-equal LastOffset.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x1, FirstSeqNo: 4, LastSeqNo: 7, FirstOffset: 400, LastOffset: 702, FirstChecksum: 0x44},
+			err: "expected monotonic LastOffset: .*",
+		},
+		// Equal-left (note FirstOffset need not be equal, and largest is preferred).
+		{
+			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 210, LastOffset: 901, FirstChecksum: 0x22},
+			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 210, LastOffset: 901, FirstChecksum: 0x22},
+		},
+		// Equal-left, but checksum mismatch.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 9, FirstOffset: 210, LastOffset: 901, FirstChecksum: 0xbad},
+			err: "expected FirstChecksum equality: .*",
+		},
+		// Identity.
+		{
+			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 190, LastOffset: 701, FirstChecksum: 0x22},
+			b: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 000, FirstChecksum: 0x22},
+			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+		},
+		// Adjacent.
+		{
+			a: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 4, FirstOffset: 200, LastOffset: 401, FirstChecksum: 0x22},
+			b: Segment{Author: 0x1, FirstSeqNo: 5, LastSeqNo: 7, FirstOffset: 500, LastOffset: 701, FirstChecksum: 0x55},
+			e: Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 7, FirstOffset: 200, LastOffset: 701, FirstChecksum: 0x22},
+		},
+		// Adjacent, but different authors.
+		{
+			a:   Segment{Author: 0x1, FirstSeqNo: 2, LastSeqNo: 4, FirstOffset: 200, LastOffset: 401, FirstChecksum: 0x22},
+			b:   Segment{Author: 0x2, FirstSeqNo: 5, LastSeqNo: 7, FirstOffset: 500, LastOffset: 701, FirstChecksum: 0x55},
+			err: errNotReducible.Error(),
+		},
+	} {
+		// Verify the expected symmetric reduction.
+		var o1, err1 = reduceSegment(tc.a, tc.b)
+		var o2, err2 = reduceSegment(tc.b, tc.a)
+
+		if tc.err != "" {
+			c.Check(err1, gc.ErrorMatches, tc.err)
+			c.Check(err2, gc.ErrorMatches, tc.err)
+		} else {
+			c.Check(o1, gc.Equals, tc.e)
+			c.Check(o2, gc.Equals, tc.e)
+			c.Check(err1, gc.IsNil)
+			c.Check(err2, gc.IsNil)
+		}
+	}
+}
+
+func (s *SegmentSuite) TestSetIdentityCases(c *gc.C) {
 	// Add items of model to an empty SegmentSet. Expect to get back the model.
 	c.Check(permuteAndAdd(c, SegmentSet{}, []Segment(modelSegmentSet())),
 		gc.DeepEquals, modelSegmentSet())
 }
 
-func (s *SegmentSuite) TestInsertionCases(c *gc.C) {
+func (s *SegmentSuite) TestSetNonOverlappingInsertionCases(c *gc.C) {
 	c.Check(permuteAndAdd(c, modelSegmentSet(), []Segment{
-		{FirstSeqNo: 1, LastSeqNo: 4, Author: 2},
-		{FirstSeqNo: 12, LastSeqNo: 12, Author: 2},
-		{FirstSeqNo: 16, LastSeqNo: 18, Author: 2},
+		{Author: 0xf, FirstSeqNo: 1, LastSeqNo: 4, FirstOffset: 100, LastOffset: 401},
+		{Author: 0xf, FirstSeqNo: 12, LastSeqNo: 12, FirstOffset: 1200, LastOffset: 1201},
+		{Author: 0xf, FirstSeqNo: 16, LastSeqNo: 18, FirstOffset: 1600, LastOffset: 1801},
 	}), gc.DeepEquals, SegmentSet{
-		{FirstSeqNo: 1, LastSeqNo: 4, Author: 2},
-		{FirstSeqNo: 5, LastSeqNo: 10},
-		{FirstSeqNo: 11, LastSeqNo: 11, Author: 1},
-		{FirstSeqNo: 12, LastSeqNo: 12, Author: 2},
-		{FirstSeqNo: 13, LastSeqNo: 15, Author: 1},
-		{FirstSeqNo: 16, LastSeqNo: 18, Author: 2},
+		// Insertions are trivially interleaved with existing Segments.
+		{Author: 0xf, FirstSeqNo: 1, LastSeqNo: 4, FirstOffset: 100, LastOffset: 401},
+		{Author: 0xa, FirstSeqNo: 5, LastSeqNo: 10, FirstOffset: 500, LastOffset: 1001},
+		{Author: 0xb, FirstSeqNo: 11, LastSeqNo: 11, FirstOffset: 1100, LastOffset: 1101},
+		{Author: 0xf, FirstSeqNo: 12, LastSeqNo: 12, FirstOffset: 1200, LastOffset: 1201},
+		{Author: 0xb, FirstSeqNo: 13, LastSeqNo: 15, FirstOffset: 1300, LastOffset: 1501},
+		{Author: 0xf, FirstSeqNo: 16, LastSeqNo: 18, FirstOffset: 1600, LastOffset: 1801},
 	})
 }
 
-func (s *SegmentSuite) TestMergeCases(c *gc.C) {
+func (s *SegmentSuite) TestSetOverlapCases(c *gc.C) {
 	c.Check(permuteAndAdd(c, modelSegmentSet(), []Segment{
-		{FirstSeqNo: 1, LastSeqNo: 4},
-		{FirstSeqNo: 12, LastSeqNo: 12, Author: 1},
-		{FirstSeqNo: 16, LastSeqNo: 18, Author: 1},
+		{Author: 0xa, FirstSeqNo: 1, LastSeqNo: 4, FirstOffset: 100, LastOffset: 401},
+		{Author: 0xb, FirstSeqNo: 12, LastSeqNo: 12, FirstOffset: 1200, LastOffset: 1201},
+		{Author: 0xb, FirstSeqNo: 16, LastSeqNo: 18, FirstOffset: 1600},
 	}), gc.DeepEquals, SegmentSet{
-		{FirstSeqNo: 1, LastSeqNo: 10},
-		{FirstSeqNo: 11, LastSeqNo: 18, Author: 1},
+		{Author: 0xa, FirstSeqNo: 1, LastSeqNo: 10, FirstOffset: 100, LastOffset: 1001}, // FirstOffset updated.
+		{Author: 0xb, FirstSeqNo: 11, LastSeqNo: 18, FirstOffset: 1100},                 // LastOffset not known.
 	})
 }
 
-func (s *SegmentSuite) TestOverlapCases(c *gc.C) {
+func (s *SegmentSuite) TestSetCoveredCases(c *gc.C) {
 	c.Check(permuteAndAdd(c, modelSegmentSet(), []Segment{
-		{FirstSeqNo: 5, LastSeqNo: 9},              // No-op.
-		{FirstSeqNo: 6, LastSeqNo: 10},             // No-op.
-		{FirstSeqNo: 11, LastSeqNo: 11, Author: 1}, // No-op.
-		{FirstSeqNo: 13, LastSeqNo: 14, Author: 1}, // No-op.
-		{FirstSeqNo: 14, LastSeqNo: 15, Author: 1}, // No-op.
-		{FirstSeqNo: 11, LastSeqNo: 15, Author: 1}, // Merges.
+		{Author: 0xa, FirstSeqNo: 5, LastSeqNo: 9, FirstOffset: 500},    // No-op.
+		{Author: 0xa, FirstSeqNo: 6, LastSeqNo: 10, FirstOffset: 600},   // No-op.
+		{Author: 0xb, FirstSeqNo: 11, LastSeqNo: 11, FirstOffset: 1100}, // No-op.
+		{Author: 0xb, FirstSeqNo: 13, LastSeqNo: 14, FirstOffset: 1300}, // No-op.
+		{Author: 0xb, FirstSeqNo: 14, LastSeqNo: 15, FirstOffset: 1400}, // No-op.
+	}), gc.DeepEquals, modelSegmentSet())
+}
+
+func (s *SegmentSuite) TestSetPointExtensions(c *gc.C) {
+	c.Check(permuteAndAdd(c, modelSegmentSet(), []Segment{
+		{Author: 0xb, FirstSeqNo: 16, FirstOffset: 1600, LastSeqNo: 16, LastOffset: 1601},
+		{Author: 0xb, FirstSeqNo: 17, FirstOffset: 1700, LastSeqNo: 17, LastOffset: 1701},
+		{Author: 0xb, FirstSeqNo: 18, FirstOffset: 1800, LastSeqNo: 18, LastOffset: 1801},
+		{Author: 0xc, FirstSeqNo: 19, FirstOffset: 1900, LastSeqNo: 19, LastOffset: 0000},
+		{Author: 0xc, FirstSeqNo: 20, FirstOffset: 2000, LastSeqNo: 20, LastOffset: 0000},
 	}), gc.DeepEquals, SegmentSet{
-		{FirstSeqNo: 5, LastSeqNo: 10},
-		{FirstSeqNo: 11, LastSeqNo: 15, Author: 1},
+		{Author: 0xa, FirstSeqNo: 5, LastSeqNo: 10, FirstOffset: 500, LastOffset: 1001},
+		{Author: 0xb, FirstSeqNo: 11, LastSeqNo: 11, FirstOffset: 1100, LastOffset: 1101},
+		{Author: 0xb, FirstSeqNo: 13, LastSeqNo: 18, FirstOffset: 1300, LastOffset: 1801},
+		{Author: 0xc, FirstSeqNo: 19, LastSeqNo: 20, FirstOffset: 1900, LastOffset: 0000},
 	})
 }
 
-func (s *SegmentSuite) TestPointExtensions(c *gc.C) {
-	c.Check(permuteAndAdd(c, modelSegmentSet(), []Segment{
-		{FirstSeqNo: 16, LastSeqNo: 16, Author: 1},
-		{FirstSeqNo: 17, LastSeqNo: 17, Author: 1},
-		{FirstSeqNo: 18, LastSeqNo: 18, Author: 1},
-		{FirstSeqNo: 19, LastSeqNo: 19, Author: 2},
-		{FirstSeqNo: 20, LastSeqNo: 20, Author: 2},
-	}), gc.DeepEquals, SegmentSet{
-		{FirstSeqNo: 5, LastSeqNo: 10},
-		{FirstSeqNo: 11, LastSeqNo: 11, Author: 1},
-		{FirstSeqNo: 13, LastSeqNo: 18, Author: 1},
-		{FirstSeqNo: 19, LastSeqNo: 20, Author: 2},
-	})
-}
-
-func (s *SegmentSuite) TestInconsistencyChecks(c *gc.C) {
+func (s *SegmentSuite) TestSetConsistencyChecks(c *gc.C) {
 	var model = modelSegmentSet()
-	for i := range model {
-		model[i].FirstOffset = int64(i) // Apply increasing offsets to |model|.
-	}
 
-	var cases = []Segment{
-		// Internal inconsistency.
-		{LastSeqNo: 5, FirstSeqNo: 6},
+	var cases = []struct {
+		Segment
+		err string
+	}{
 		// Overlapping, incorrect author.
-		{FirstSeqNo: 4, LastSeqNo: 5, Author: 2},
-		{FirstSeqNo: 10, LastSeqNo: 11, Author: 0},
-		{FirstSeqNo: 10, LastSeqNo: 11, Author: 1},
-		{FirstSeqNo: 15, LastSeqNo: 15, Author: 2},
-		// Non-monotonic offset.
-		{FirstSeqNo: 12, LastSeqNo: 12, Author: 1, FirstOffset: 0},
-		{FirstSeqNo: 11, LastSeqNo: 12, Author: 1, FirstOffset: 2},
+		{Segment{Author: 0xc, FirstSeqNo: 4, LastSeqNo: 5, FirstOffset: 400, LastOffset: 501},
+			"expected Segment Author equality: .*"},
+		{Segment{Author: 0xa, FirstSeqNo: 10, LastSeqNo: 11, FirstOffset: 1000, LastOffset: 1101},
+			"expected Segment Author equality: .*"},
+		{Segment{Author: 0xb, FirstSeqNo: 10, LastSeqNo: 11, FirstOffset: 1000, LastOffset: 1101},
+			"expected Segment Author equality: .*"},
+		{Segment{Author: 0xc, FirstSeqNo: 15, LastSeqNo: 15, FirstOffset: 1500, LastOffset: 1501},
+			"expected Segment Author equality: .*"},
+		// Missing LastOffset.
+		{Segment{Author: 0xb, FirstSeqNo: 12, LastSeqNo: 12, FirstOffset: 1200, LastOffset: 000},
+			"expected preceding Segment to also include LastOffset: .*"},
+		// Non-monotonic offsets.
+		{Segment{Author: 0xb, FirstSeqNo: 12, LastSeqNo: 12, FirstOffset: 1050, LastOffset: 1200},
+			"expected monotonic FirstOffset: .*"},
+		{Segment{Author: 0xa, FirstSeqNo: 3, LastSeqNo: 3, FirstOffset: 300, LastOffset: 1050},
+			"expected monotonic LastOffset: .*"},
 	}
 
 	for _, tc := range cases {
-		c.Check(model.Add(tc), gc.NotNil)
+		c.Check(model.Add(tc.Segment), gc.ErrorMatches, tc.err)
 	}
 }
 
@@ -109,9 +252,9 @@ func permuteAndAdd(c *gc.C, to SegmentSet, from []Segment) SegmentSet {
 
 func modelSegmentSet() SegmentSet {
 	return SegmentSet{
-		{FirstSeqNo: 5, LastSeqNo: 10},
-		{FirstSeqNo: 11, LastSeqNo: 11, Author: 1},
-		{FirstSeqNo: 13, LastSeqNo: 15, Author: 1},
+		{Author: 0xa, FirstSeqNo: 5, LastSeqNo: 10, FirstOffset: 500, LastOffset: 1001},
+		{Author: 0xb, FirstSeqNo: 11, LastSeqNo: 11, FirstOffset: 1100, LastOffset: 1101},
+		{Author: 0xb, FirstSeqNo: 13, LastSeqNo: 15, FirstOffset: 1300, LastOffset: 1501},
 	}
 }
 

--- a/pkg/recoverylog/segment_test.go
+++ b/pkg/recoverylog/segment_test.go
@@ -243,6 +243,41 @@ func (s *SegmentSuite) TestSetConsistencyChecks(c *gc.C) {
 	}
 }
 
+func (s *SegmentSuite) TestIntersectionCases(c *gc.C) {
+	var model = modelSegmentSet()
+
+	var cases = []struct {
+		first, last int64
+		expect      SegmentSet
+	}{
+		{0, 100000, model},
+		{0, 500, model[0:0]},
+		{0, 501, model[0:1]},
+		{1000, 1001, model[0:1]},
+		{1000, 1100, model[0:1]},
+		{1000, 1101, model[0:2]},
+		{1000, 1300, model[0:2]},
+		{1000, 1301, model},
+		{1000, 100000, model},
+		{1001, 1001, model[1:1]},
+		{1001, 1100, model[1:1]},
+		{1001, 1101, model[1:2]},
+		{1100, 1101, model[1:2]},
+		{1101, 1101, model[2:2]},
+		{1101, 1300, model[2:2]},
+		{1101, 1301, model[2:3]},
+		{1300, 1301, model[2:3]},
+		{1300, 100000, model[2:3]},
+		{1500, 100000, model[2:3]},
+		{1501, 100000, model[3:3]},
+		{10000, 100000, model[3:3]},
+	}
+
+	for _, tc := range cases {
+		c.Check(model.Intersect(tc.first, tc.last), gc.DeepEquals, tc.expect)
+	}
+}
+
 func permuteAndAdd(c *gc.C, to SegmentSet, from []Segment) SegmentSet {
 	for _, i := range rand.Perm(len(from)) {
 		c.Check(to.Add(from[i]), gc.IsNil)


### PR DESCRIPTION
This PR adds a `gazctl shard prune-log` command, as well as a number of related underlying changes.

Log pruning identifies Fragments of a hinted recovery log which can safely be removed, while preserving the ability to play back the pruned hints.

The intention is that regular pruning would be operational-ized by pointing `gazctl` as `.lastRecovered` hints of consumer shards.

Extensive testing against the `stream-sum` example was performed by:
 * Heavily and continuously loading a local stack
 * Regularly deleting the `stream-sum-summer` consumer pods, to force playback and recovery.
 * Regularly using the `gazctl shard prune-log` command to prune both `.lastRecovered` and also primary hint paths.
 * Verifying that no playback errors occurred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/45)
<!-- Reviewable:end -->
