### PR TITLE
Add RetryReader.AdjustedSeek, and use in recoverylog playback

### DIFF
--- a/pkg/recoverylog/playback.go
+++ b/pkg/recoverylog/playback.go
@@ -198,10 +198,9 @@ func prepareRead(ctx context.Context, pr *playerReader, nextOffset int64, block 
 
 	if !pr.pendingPeek && pr.rr.AdjustedMark(pr.br).Offset != nextOffset {
 		// Seek the RetryReader forward to the next hinted offset.
-		if _, err := pr.rr.Seek(nextOffset, io.SeekStart); err != nil {
+		if _, err := pr.rr.AdjustedSeek(nextOffset, io.SeekStart, pr.br); err != nil {
 			panic(err) // The contract for RetryReader.Seek is that it never return an error.
 		}
-		pr.br.Reset(&pr.rr)
 	}
 
 	return pr


### PR DESCRIPTION
AdjustedSeek performs a Seek taking into account a current buffer, which
may be able to satisfy the seek without involving the underlying reader.

In particular, this change prevents very short seeks from triggering a
re-open of the underlying reader.

Issue #51

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/52)
<!-- Reviewable:end -->
