### PR TITLE
consumer: maintain GRPC connections to all PRIMARY endpoints

### DIFF
--- a/pkg/consumer/client_test.go
+++ b/pkg/consumer/client_test.go
@@ -12,18 +12,19 @@ import (
 type ClientSuite struct{}
 
 func (s *ClientSuite) TestClientInitializationAndUpdate(c *gc.C) {
-	var s0, s1 = buildMockServer(c), buildMockServer(c)
+	var s0, s1, s2 = buildMockServer(c), buildMockServer(c), buildMockServer(c)
 	defer s0.srv.GracefulStop()
 	defer s1.srv.GracefulStop()
+	defer s2.srv.GracefulStop()
 
 	s0.mock.On("CurrentConsumerState", mock.Anything, &Empty{}).Return(
-		buildConsumerStateFixture(s0.addr, s1.addr), nil).Once()
+		buildConsumerStateFixture(s0.addr, s1.addr, s2.addr), nil).Once()
 
 	var client, err = NewClient(s0.addr)
 	c.Check(err, gc.IsNil)
 	defer client.Close()
 
-	c.Check(client.State(), gc.DeepEquals, *buildConsumerStateFixture(s0.addr, s1.addr))
+	c.Check(client.State(), gc.DeepEquals, *buildConsumerStateFixture(s0.addr, s1.addr, s2.addr))
 
 	conn, shard, err := client.PartitionClient("partition/zero")
 	c.Check(err, gc.IsNil)
@@ -36,28 +37,28 @@ func (s *ClientSuite) TestClientInitializationAndUpdate(c *gc.C) {
 	c.Check(shard.Id, gc.Equals, ShardID("shard-one"))
 
 	conn, shard, err = client.PartitionClient("partition/two")
-	c.Check(err, gc.Equals, ErrNoReadyPartitionClient)
-	c.Check(conn, gc.IsNil)
+	c.Check(err, gc.IsNil)
+	c.Check(conn, gc.NotNil)
 	c.Check(shard.Id, gc.Equals, ShardID("shard-two"))
 
 	conn, shard, err = client.PartitionClient("partition/three")
 	c.Check(err, gc.Equals, ErrNoSuchConsumerPartition)
 	c.Check(conn, gc.IsNil)
 
-	var s2 = buildMockServer(c)
-	defer s2.srv.GracefulStop()
+	var s3 = buildMockServer(c)
+	defer s3.srv.GracefulStop()
 
 	// Add a new server and define shard-three.
-	var fixture = buildConsumerStateFixture(s0.addr, s1.addr)
+	var fixture = buildConsumerStateFixture(s0.addr, s1.addr, s2.addr)
 
-	fixture.Endpoints = sortStrings([]string{s0.addr, s1.addr, s2.addr})
+	fixture.Endpoints = sortStrings([]string{s0.addr, s1.addr, s3.addr})
 	fixture.Shards = append(fixture.Shards, ConsumerState_Shard{
 		Id:        "shard-three",
 		Topic:     "a/topic",
 		Partition: "partition/three",
 		Replicas: []ConsumerState_Replica{
 			{
-				Endpoint: s2.addr,
+				Endpoint: s3.addr,
 				Status:   ConsumerState_Replica_PRIMARY,
 			},
 		},
@@ -102,7 +103,7 @@ func buildMockServer(c *gc.C) mockConsumerServer {
 	}
 }
 
-func buildConsumerStateFixture(addr0, addr1 string) *ConsumerState {
+func buildConsumerStateFixture(addr0, addr1, addr2 string) *ConsumerState {
 	return &ConsumerState{
 		Root:          "a/root",
 		LocalRouteKey: addr0,
@@ -137,15 +138,20 @@ func buildConsumerStateFixture(addr0, addr1 string) *ConsumerState {
 					},
 				},
 			},
-			// shard-two is PRIMARY but not addressable (non-member endpoint in process of hand-off).
+			// shard-two is PRIMARY and addressable, though not in Endpoints (eg, member is in process of hand-off).
+			// It's replica is not accessible (but not connected to, either, as non-PRIMARY).
 			{
 				Id:        "shard-two",
 				Topic:     "a/topic",
 				Partition: "partition/two",
 				Replicas: []ConsumerState_Replica{
 					{
-						Endpoint: "[100::1]:1234", // RFC 6666 black-hole IP.
+						Endpoint: addr2,
 						Status:   ConsumerState_Replica_PRIMARY,
+					},
+					{
+						Endpoint: "[100::1]:1234", // RFC 6666 black-hole IP.
+						Status:   ConsumerState_Replica_READY,
 					},
 				},
 			},


### PR DESCRIPTION
Even if they're not explicitly listed in ConsumerState.Endpoints. This
allows clients to talk to PRIMARY shards hosted by members in the
process of shutting down. That shut-down could take a while, as shards
are recovered by other processes, and clients should be able to access
shards in the meantime.

Issue #50

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/53)
<!-- Reviewable:end -->
