### PR TITLE
Add error check to Close in SFTP CopyAtomic

### DIFF
--- a/pkg/cloudstore/filesystem.go
+++ b/pkg/cloudstore/filesystem.go
@@ -42,7 +42,7 @@ type FileSystem interface {
 	// (either via |to.Write()| or *|from.Read()|*), the partially-written content
 	// is removed or never made observable on the target FileSystem (depending on
 	// provider semantics). Otherwise, |to| is visible on the FileSystem after
-	// the call completes. In all cases, |from| is invalidated (eg, Close()d)
+	// the call completes. In all cases, |to| is invalidated (eg, Close()d)
 	// after this call. Re-tryable bulk transfers should generally use
 	// this method for all-or-nothing behavior.
 	CopyAtomic(to File, from io.Reader) (n int64, err error)

--- a/pkg/cloudstore/sftp_fs.go
+++ b/pkg/cloudstore/sftp_fs.go
@@ -323,7 +323,7 @@ func (s *sftpFs) CopyAtomic(to File, from io.Reader) (n int64, err error) {
 	if n, err = io.Copy(to, from); err != nil {
 		s.Remove(to.(*sftpFile).partialPath)
 	} else {
-		to.Close()
+		err = to.Close()
 	}
 	return
 }


### PR DESCRIPTION
Currently if a copy is successful, but an error occurs while closing the
file, that error is discarded. We should have visibility on errors which
occur during the close.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/54)
<!-- Reviewable:end -->
