### PR TITLE
Track failed writes as a metric rather than a log statement.

### DIFF
--- a/pkg/gazette/write_service.go
+++ b/pkg/gazette/write_service.go
@@ -206,6 +206,7 @@ func (c *WriteService) serveWrites(index int) {
 		c.writeIndexMu.Unlock()
 
 		if err := c.onWrite(write); err != nil {
+			metrics.GazetteWriteFailureTotal.Inc()
 			log.WithFields(log.Fields{"journal": write.journal, "err": err}).
 				Error("write failed")
 		}
@@ -246,8 +247,7 @@ func (c *WriteService) onWrite(write *pendingWrite) error {
 			continue
 
 		default:
-			log.WithFields(log.Fields{"journal": write.journal, "err": result.Error}).
-				Warn("write failed")
+			metrics.GazetteWriteFailureTotal.Inc()
 			time.Sleep(writeServiceCoolOffTimeout)
 			continue
 		}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -109,6 +109,7 @@ const (
 	GazetteWriteBytesTotalKey           = "gazette_write_bytes_total"
 	GazetteWriteCountTotalKey           = "gazette_write_count_total"
 	GazetteWriteDurationSecondsTotalKey = "gazette_write_duration_seconds_total"
+	GazetteWriteFailureTotalKey         = "gazette_write_failure_total"
 )
 
 // Collectors for gazette.Client and gazette.WriteService metrics.
@@ -133,6 +134,10 @@ var (
 	GazetteWriteDurationTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: GazetteWriteDurationSecondsTotalKey,
 		Help: "Cumulative number of seconds spent writing.",
+	})
+	GazetteWriteFailureTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: GazetteWriteFailureTotalKey,
+		Help: "Cumulative number of write errors returned to clients.",
 	})
 )
 


### PR DESCRIPTION
The log statement can be very spammy, and we don't look at it, so
instead, we should measure write failure rates and alert on those via
automation instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/55)
<!-- Reviewable:end -->
