### PR TITLE
Separate file close from buffer flush

### DIFF
--- a/pkg/cloudstore/sftp_fs.go
+++ b/pkg/cloudstore/sftp_fs.go
@@ -94,7 +94,9 @@ func (f *sftpFile) Close() error {
 		// Fall through
 	} else if err := f.buf.Flush(); err != nil {
 		return fmt.Errorf("flushing buffer: %s", err.Error())
-	} else if err := f.File.Close(); err != nil {
+	}
+
+	if err := f.File.Close(); err != nil {
 		return fmt.Errorf("closing file: %s", err.Error())
 	}
 	return nil


### PR DESCRIPTION
Within the Close function on SFTP Files, the condition is written such that if a file's write buffer is nil, the condition exits without flushing said buffer or closing the file. While the former is appropriate behavior, the latter is not. A File which has not had its Write function called (and therefore had a write buffer created) will never have its underlying file closed.

In particular, this presents an issue when used with the newer version of pkg/sftp we recently upgraded to. 

- The new version of the pkg/sftp File includes a ReadFrom function.
- The stdlib io.Copy function checks for the presence of a ReadFrom function on destination files. If present, it will prefer that over base Read/Write.
- CopyAtomic in the cloudstore package is implemented using io.Copy.
- When an SFTP file is the destination of a CopyAtomic, its Write function is therefore never invoked.
- The underlying SFTP file is never closed (ie, no close command is sent to the SFTP server).

Since LiveRamp's SFTP upload processing relies on a STOR command being recorded, files which are not properly closed are never processed.

This fix will ensure all files are actually closed when the Close function is called on them, regardless of whether they have a write buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/56)
<!-- Reviewable:end -->
