### PR TITLE
Track failures as metrics rather than log statements.

### DIFF
--- a/cmd/run-consumer/main.go
+++ b/cmd/run-consumer/main.go
@@ -54,6 +54,7 @@ func (cfg Config) Validate() error {
 func main() {
 	prometheus.MustRegister(metrics.GazetteClientCollectors()...)
 	prometheus.MustRegister(metrics.GazetteConsumerCollectors()...)
+	prometheus.MustRegister(metrics.GazetteConsumerHealthCollectors()...)
 	flag.Parse()
 
 	if *configFile != "" {

--- a/cmd/run-consumer/main.go
+++ b/cmd/run-consumer/main.go
@@ -54,7 +54,6 @@ func (cfg Config) Validate() error {
 func main() {
 	prometheus.MustRegister(metrics.GazetteClientCollectors()...)
 	prometheus.MustRegister(metrics.GazetteConsumerCollectors()...)
-	prometheus.MustRegister(metrics.GazetteConsumerHealthCollectors()...)
 	flag.Parse()
 
 	if *configFile != "" {

--- a/pkg/consumer/replica.go
+++ b/pkg/consumer/replica.go
@@ -1,10 +1,10 @@
 package consumer
 
 import (
+	"context"
+
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
-
-	"context"
 
 	"github.com/LiveRamp/gazette/pkg/metrics"
 	"github.com/LiveRamp/gazette/pkg/recoverylog"

--- a/pkg/consumer/replica.go
+++ b/pkg/consumer/replica.go
@@ -44,7 +44,7 @@ func (r *replica) serve(runner *Runner) {
 	if err := r.player.Play(runner.Gazette); err != nil {
 		switch err {
 		case context.Canceled:
-			metrics.GazetteConsumerFailedReplications.Inc()
+			metrics.GazetteConsumerCanceledContextsTotal.Inc()
 		default:
 			log.WithFields(log.Fields{"shard": r.shard, "err": err}).Error("replication failed")
 		}

--- a/pkg/consumer/replica.go
+++ b/pkg/consumer/replica.go
@@ -6,7 +6,6 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/LiveRamp/gazette/pkg/metrics"
 	"github.com/LiveRamp/gazette/pkg/recoverylog"
 )
 
@@ -44,7 +43,7 @@ func (r *replica) serve(runner *Runner) {
 	if err := r.player.Play(runner.Gazette); err != nil {
 		switch err {
 		case context.Canceled:
-			metrics.GazetteConsumerCanceledContextsTotal.Inc()
+			// Do nothing, the shard is no longer being processed by this pod.
 		default:
 			log.WithFields(log.Fields{"shard": r.shard, "err": err}).Error("replication failed")
 		}

--- a/pkg/consumer/replica.go
+++ b/pkg/consumer/replica.go
@@ -4,6 +4,7 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/LiveRamp/gazette/pkg/metrics"
 	"github.com/LiveRamp/gazette/pkg/recoverylog"
 )
 
@@ -39,7 +40,7 @@ func (r *replica) serve(runner *Runner) {
 	defer close(r.servingCh)
 
 	if err := r.player.Play(runner.Gazette); err != nil {
-		log.WithFields(log.Fields{"shard": r.shard, "err": err}).Error("replication failed")
+		metrics.GazetteConsumerFailedReplications.Inc()
 		abort(runner, r.shard)
 	} else {
 		log.WithFields(log.Fields{"shard": r.shard}).Info("finished serving replica")

--- a/pkg/consumer/routines.go
+++ b/pkg/consumer/routines.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/LiveRamp/gazette/pkg/consensus"
 	"github.com/LiveRamp/gazette/pkg/journal"
+	"github.com/LiveRamp/gazette/pkg/metrics"
 	"github.com/LiveRamp/gazette/pkg/recoverylog"
 	"github.com/LiveRamp/gazette/pkg/topic"
 )
@@ -88,7 +89,7 @@ func recoveryLog(logRoot string, shard ShardID) journal.Name {
 // circumstances (eg, an unrecoverable local error).
 func abort(runner *Runner, shard ShardID) {
 	if err := consensus.CancelItem(runner, shard.String()); err != nil {
-		log.WithField("err", err).Error("failed to cancel shard lock")
+		metrics.GazetteConsumerFailedShardLock.Inc()
 	}
 }
 

--- a/pkg/consumer/routines.go
+++ b/pkg/consumer/routines.go
@@ -89,7 +89,7 @@ func recoveryLog(logRoot string, shard ShardID) journal.Name {
 // circumstances (eg, an unrecoverable local error).
 func abort(runner *Runner, shard ShardID) {
 	if err := consensus.CancelItem(runner, shard.String()); err != nil {
-		metrics.GazetteConsumerFailedShardLock.Inc()
+		metrics.GazetteConsumerFailedShardLocksTotal.Inc()
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -159,6 +159,8 @@ const (
 	GazetteConsumerTxMessagesTotalKey       = "gazette_consumer_tx_messages_total"
 	GazetteConsumerTxSecondsTotalKey        = "gazette_consumer_tx_seconds_total"
 	GazetteConsumerTxStalledSecondsTotalKey = "gazette_consumer_tx_stalled_seconds_total"
+	GazetteConsumerFailedShardLocksKey      = "gazette_failed_shard_locks_total"
+	GazetteConsumerFailedReplicationsKey    = "gazette_failed_replications_total"
 )
 
 // Collectors for consumer.Runner metrics.
@@ -179,26 +181,6 @@ var (
 		Name: GazetteConsumerTxStalledSecondsTotalKey,
 		Help: "Cumulative number of seconds transactions have stalled.",
 	})
-)
-
-// GazetteConsumerCollectors returns the metrics used by the consumer package.
-func GazetteConsumerCollectors() []prometheus.Collector {
-	return []prometheus.Collector{
-		GazetteConsumerTxCountTotal,
-		GazetteConsumerTxMessagesTotal,
-		GazetteConsumerTxSecondsTotal,
-		GazetteConsumerTxStalledSecondsTotal,
-	}
-}
-
-// Keys for gazette consumer health metrics.
-const (
-	GazetteConsumerFailedShardLocksKey   = "gazette_failed_shard_locks_total"
-	GazetteConsumerFailedReplicationsKey = "gazette_failed_replications_total"
-)
-
-// Collectors for gazette consumer health metrics.
-var (
 	GazetteConsumerFailedShardLock = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: GazetteConsumerFailedShardLocksKey,
 		Help: "Cumulative number of shard lock failures.",
@@ -209,8 +191,13 @@ var (
 	})
 )
 
-func GazetteConsumerHealthCollectors() []prometheus.Collector {
+// GazetteConsumerCollectors returns the metrics used by the consumer package.
+func GazetteConsumerCollectors() []prometheus.Collector {
 	return []prometheus.Collector{
+		GazetteConsumerTxCountTotal,
+		GazetteConsumerTxMessagesTotal,
+		GazetteConsumerTxSecondsTotal,
+		GazetteConsumerTxStalledSecondsTotal,
 		GazetteConsumerFailedShardLock,
 		GazetteConsumerFailedReplications,
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -160,7 +160,7 @@ const (
 	GazetteConsumerTxSecondsTotalKey        = "gazette_consumer_tx_seconds_total"
 	GazetteConsumerTxStalledSecondsTotalKey = "gazette_consumer_tx_stalled_seconds_total"
 	GazetteConsumerFailedShardLocksKey      = "gazette_failed_shard_locks_total"
-	GazetteConsumerFailedReplicationsKey    = "gazette_failed_replications_total"
+	GazetteConsumerContextCanceledKey       = "gazette_failed_replications_total"
 )
 
 // Collectors for consumer.Runner metrics.
@@ -181,13 +181,13 @@ var (
 		Name: GazetteConsumerTxStalledSecondsTotalKey,
 		Help: "Cumulative number of seconds transactions have stalled.",
 	})
-	GazetteConsumerFailedShardLock = prometheus.NewCounter(prometheus.CounterOpts{
+	GazetteConsumerFailedShardLocksTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: GazetteConsumerFailedShardLocksKey,
 		Help: "Cumulative number of shard lock failures.",
 	})
-	GazetteConsumerFailedReplications = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: GazetteConsumerFailedReplicationsKey,
-		Help: "Cumulative number of replication failures.",
+	GazetteConsumerCanceledContextsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: GazetteConsumerContextCanceledKey,
+		Help: "Cumulative number of canceled contexts.",
 	})
 )
 
@@ -198,7 +198,7 @@ func GazetteConsumerCollectors() []prometheus.Collector {
 		GazetteConsumerTxMessagesTotal,
 		GazetteConsumerTxSecondsTotal,
 		GazetteConsumerTxStalledSecondsTotal,
-		GazetteConsumerFailedShardLock,
-		GazetteConsumerFailedReplications,
+		GazetteConsumerFailedShardLocksTotal,
+		GazetteConsumerCanceledContextsTotal,
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -190,3 +190,28 @@ func GazetteConsumerCollectors() []prometheus.Collector {
 		GazetteConsumerTxStalledSecondsTotal,
 	}
 }
+
+// Keys for gazette consumer health metrics.
+const (
+	GazetteConsumerFailedShardLocksKey   = "gazette_failed_shard_locks_total"
+	GazetteConsumerFailedReplicationsKey = "gazette_failed_replications_total"
+)
+
+// Collectors for gazette consumer health metrics.
+var (
+	GazetteConsumerFailedShardLock = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: GazetteConsumerFailedShardLocksKey,
+		Help: "Cumulative number of shard lock failures.",
+	})
+	GazetteConsumerFailedReplications = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: GazetteConsumerFailedReplicationsKey,
+		Help: "Cumulative number of replication failures.",
+	})
+)
+
+func GazetteConsumerHealthCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		GazetteConsumerFailedShardLock,
+		GazetteConsumerFailedReplications,
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -159,8 +159,7 @@ const (
 	GazetteConsumerTxMessagesTotalKey       = "gazette_consumer_tx_messages_total"
 	GazetteConsumerTxSecondsTotalKey        = "gazette_consumer_tx_seconds_total"
 	GazetteConsumerTxStalledSecondsTotalKey = "gazette_consumer_tx_stalled_seconds_total"
-	GazetteConsumerFailedShardLocksKey      = "gazette_failed_shard_locks_total"
-	GazetteConsumerCanceledContextsKey      = "gazette_failed_replications_total"
+	GazetteConsumerFailedShardLocksKey      = "gazette_consumer_failed_shard_locks_total"
 )
 
 // Collectors for consumer.Runner metrics.
@@ -185,10 +184,6 @@ var (
 		Name: GazetteConsumerFailedShardLocksKey,
 		Help: "Cumulative number of shard lock failures.",
 	})
-	GazetteConsumerCanceledContextsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: GazetteConsumerCanceledContextsKey,
-		Help: "Cumulative number of canceled contexts.",
-	})
 )
 
 // GazetteConsumerCollectors returns the metrics used by the consumer package.
@@ -199,6 +194,5 @@ func GazetteConsumerCollectors() []prometheus.Collector {
 		GazetteConsumerTxSecondsTotal,
 		GazetteConsumerTxStalledSecondsTotal,
 		GazetteConsumerFailedShardLocksTotal,
-		GazetteConsumerCanceledContextsTotal,
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -160,7 +160,7 @@ const (
 	GazetteConsumerTxSecondsTotalKey        = "gazette_consumer_tx_seconds_total"
 	GazetteConsumerTxStalledSecondsTotalKey = "gazette_consumer_tx_stalled_seconds_total"
 	GazetteConsumerFailedShardLocksKey      = "gazette_failed_shard_locks_total"
-	GazetteConsumerContextCanceledKey       = "gazette_failed_replications_total"
+	GazetteConsumerCanceledContextsKey      = "gazette_failed_replications_total"
 )
 
 // Collectors for consumer.Runner metrics.
@@ -186,7 +186,7 @@ var (
 		Help: "Cumulative number of shard lock failures.",
 	})
 	GazetteConsumerCanceledContextsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: GazetteConsumerContextCanceledKey,
+		Name: GazetteConsumerCanceledContextsKey,
 		Help: "Cumulative number of canceled contexts.",
 	})
 )


### PR DESCRIPTION
We notice a lot of transient errors which create a lot of noise. Instead we'd like to push these failures to prometheus which can then be alerted on if we see a large number of them in a short period of time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/61)
<!-- Reviewable:end -->
