### PR TITLE
Consistent etcd config

### DIFF
--- a/cmd/gazctl/cmd/root.go
+++ b/cmd/gazctl/cmd/root.go
@@ -81,7 +81,7 @@ func etcdClient() etcd.Client {
 		}
 
 		var err error
-		lazyEtcdClient, err = etcd.New(etcd.Config{Endpoints: []string{ep}})
+		lazyEtcdClient, err = etcd.New(etcd.Config{Endpoints: []string{"http://" + ep}})
 		if err != nil {
 			log.WithField("err", err).Fatal("building etcd client")
 		}


### PR DESCRIPTION
We prepend "http://" to the etcd endpoint in gazette itself: https://github.com/LiveRamp/gazette/blob/master/cmd/gazette/main.go#L76

We should handle these endpoints consistently in our command line tools so that users don't need to pass configs in different formats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/62)
<!-- Reviewable:end -->
