### PR TITLE
Fix behavior of CopyAtomic for S3 files

### DIFF
--- a/pkg/cloudstore/s3_file.go
+++ b/pkg/cloudstore/s3_file.go
@@ -386,22 +386,3 @@ func (f *s3File) listObjects() ([]os.FileInfo, error) {
 func (f *s3File) isUpload() bool {
 	return f.uploadId != nil
 }
-
-func (f *s3File) transfer(from io.Reader) (int64, error) {
-	var n int64
-	if f.compressor != nil {
-		n, f.err = io.Copy(f.compressor, from)
-	} else {
-		var buf = &f.spool
-		n, f.err = io.Copy(buf, from)
-	}
-
-	if f.err != nil {
-		if f.compressor != nil {
-			f.compressor.Close()
-		}
-		return n, f.err
-	}
-
-	return n, f.Close()
-}

--- a/pkg/cloudstore/s3_fs.go
+++ b/pkg/cloudstore/s3_fs.go
@@ -253,7 +253,12 @@ func (fs *s3Fs) Remove(name string) error {
 // guarantees provided by Amazon S3. In particular, |to| is aborted
 // (s3File.uploadId is aborted explicitly) if a write *or read* error occurs.
 func (fs *s3Fs) CopyAtomic(to File, from io.Reader) (n int64, err error) {
-	return to.(*s3File).transfer(from)
+	if n, err = io.Copy(to.(*s3File), from); err == nil {
+		// Completes the multipart upload.
+		to.Close()
+	}
+	return
+
 }
 
 // For the specified |path|, generates a signed URL which makes it so that the

--- a/pkg/cloudstore/s3_fs.go
+++ b/pkg/cloudstore/s3_fs.go
@@ -253,7 +253,7 @@ func (fs *s3Fs) Remove(name string) error {
 // guarantees provided by Amazon S3. In particular, |to| is aborted
 // (s3File.uploadId is aborted explicitly) if a write *or read* error occurs.
 func (fs *s3Fs) CopyAtomic(to File, from io.Reader) (n int64, err error) {
-	if n, err = io.Copy(to.(*s3File), from); err == nil {
+	if n, err = io.Copy(to, from); err == nil {
 		// Completes the multipart upload.
 		to.Close()
 	}


### PR DESCRIPTION
As written, calls to CopyAtomic will read the entire source file to memory before sending it to the multipart upload function. Ideally, what we want is for the file to be uploaded in chunks so that the size of the spool doesn't get out of control. Restoring the old version of the CopyAtomic function will do exactly this (since under the hood io.Copy will call the Write function of s3File, which does this chunking).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/70)
<!-- Reviewable:end -->
