### PR TITLE
Repartition mapper

### DIFF
--- a/cmd/Special_operations.md
+++ b/cmd/Special_operations.md
@@ -1,6 +1,5 @@
-Special Operations
-
 Shard repartitioning
+====================
 
 The amount of data that a consumer process has to process is determined by the size of the partitions of the Gazette topic it is reading from. Each partition defines one consumer shard, and you can't process less than one shard at a time. Consequently, it is very important to get the initial partitioning of your topics right from the start. Partitions should be written to evenly so that they are approximately the same size, and there should be enough of them that they don't receive new writes at such a high rate that consumers following along cannot keep up. Over time, the requirements of consumers may change and the amount of data written to a topic may increase as applications scale. It is often necessary to readjust the way that data is partitioned across topic partitions and consumer shards after they have been begun running in production. Without repartitioning, you may find that the keyspace a consumer shard has to deal with grows too large to comfortably fit on disk, or that a consumer shard becomes unable to keep up with the rate of new writes to a topic partition.
 
@@ -14,18 +13,18 @@ This resharding can be accomplished by combining a few commands given in gazctl 
 
 This produces a set of recovery logs that allow you to spin up a new consumer that will seamlessly continue processing from a repartitioned source topic.
 
-Recover shards into local rocks databases
+### Recover shards into local rocks databases
 
 Before you start operating on shards, you want a stable snapshot of the state of each shard database at a given time. `gazctl shard recover` provides this for you -- it takes a recovery and an optional hints file and replays it into a local rocks database.
 
-Map data to new shards
+### Map data to new shards
 
 gazctl shard split provides this functionality. You can customize how your data is split into new shards by providing a `shard_ctl` plugin that implements the Split type. The output will be multiple text files consisting of hex-encoded key-value pairs, each holding some fragment of the keyspace.
 
-Stitch together new shards
+### Stitch together new shards
 
 If you are just splitting up shards independently, not rearranging data between shards, you can skip this step. However, you may have a situation where you have multiple files that you want to combine into a single rocks database. gazctl shard compose allows you to take multiple input sources and combine them. If multiple input files may share some of the keys, you can also customize how they are merged into a single value by implementing the Merge type in the `shard_ctl` plugin
 
-Write new recovery logs
+### Write new recovery logs
 
 `gazctl shard compose` will handle this automatically for you, even if your shards only have a single input source. Just use the `recovery-log` option and it will write a recovery log replaying the rocksdb file operations needed to quickly reconstruct your output shard. Then you can stand up a new set of production consumer instances for these new shards that will smoothly resume from your new source partitions and recovery logs

--- a/cmd/Special_operations.md
+++ b/cmd/Special_operations.md
@@ -1,0 +1,31 @@
+Special Operations
+
+Shard repartitioning
+
+The amount of data that a consumer process has to process is determined by the size of the partitions of the Gazette topic it is reading from. Each partition defines one consumer shard, and you can't process less than one shard at a time. Consequently, it is very important to get the initial partitioning of your topics right from the start. Partitions should be written to evenly so that they are approximately the same size, and there should be enough of them that they don't receive new writes at such a high rate that consumers following along cannot keep up. Over time, the requirements of consumers may change and the amount of data written to a topic may increase as applications scale. It is often necessary to readjust the way that data is partitioned across topic partitions and consumer shards after they have been begun running in production. Without repartitioning, you may find that the keyspace a consumer shard has to deal with grows too large to comfortably fit on disk, or that a consumer shard becomes unable to keep up with the rate of new writes to a topic partition.
+
+Repartitioning new writes to a topic is easy: you just have to adjust the way the process performing writes routes keys to partitions. But active consumers may already have a large amount of state built up, and repartitioning a topic may mean that some of their keys now properly belong to other shards. Resharding that historical data won't happen by itself, and it requires special attention.
+
+This resharding can be accomplished by combining a few commands given in gazctl to perform a map-reduce on the shards. The steps are, essentially, 
+* recover existing shards into local rocks databases
+* map data in existing shards to a new set of shards
+* stitch together all data that belongs to a given shard into a new rocks database
+* write a recovery log and hints for each recomposed shard
+
+This produces a set of recovery logs that allow you to spin up a new consumer that will seamlessly continue processing from a repartitioned source topic.
+
+Recover shards into local rocks databases
+
+Before you start operating on shards, you want a stable snapshot of the state of each shard database at a given time. `gazctl shard recover` provides this for you -- it takes a recovery and an optional hints file and replays it into a local rocks database.
+
+Map data to new shards
+
+gazctl shard split provides this functionality. You can customize how your data is split into new shards by providing a `shard_ctl` plugin that implements the Split type. The output will be multiple text files consisting of hex-encoded key-value pairs, each holding some fragment of the keyspace.
+
+Stitch together new shards
+
+If you are just splitting up shards independently, not rearranging data between shards, you can skip this step. However, you may have a situation where you have multiple files that you want to combine into a single rocks database. gazctl shard compose allows you to take multiple input sources and combine them. If multiple input files may share some of the keys, you can also customize how they are merged into a single value by implementing the Merge type in the `shard_ctl` plugin
+
+Write new recovery logs
+
+`gazctl shard compose` will handle this automatically for you, even if your shards only have a single input source. Just use the `recovery-log` option and it will write a recovery log replaying the rocksdb file operations needed to quickly reconstruct your output shard. Then you can stand up a new set of production consumer instances for these new shards that will smoothly resume from your new source partitions and recovery logs

--- a/cmd/gazctl/cmd/plugin_types.go
+++ b/cmd/gazctl/cmd/plugin_types.go
@@ -1,10 +1,26 @@
 package cmd
 
+import (
+	"crypto"
+)
+
 // When shard_compose finds the same key in multiple different input sources, it has to select a single value
 // to take the place of the n incoming values. Implement this interface to choose a different behavior for how
 // multiple keys will be merged.
 type Merge func(key []byte, values [][]byte) []byte
 
+// Default Merge function
 func First(key []byte, values [][]byte) []byte {
 	return values[0]
+}
+
+// shard_split partitions a shard into multiple shards with smaller keyspaces. In order to do this partitioning, you must
+// specify how you want shards to choose where to put each key. This function takes in a key and the index
+// of the original shard you're processing and outputs an index for the new shard that it will be assigned to.
+type Split func(originalPartition int, key []byte) int
+
+// Example of a Split function that splits keys in a shard in half arbitrarily
+func Halve(originalPartition int, key []byte) int {
+	h := crypto.MD5.New().Sum(key)
+	return originalPartition + int(h[len(h)-1])%2
 }

--- a/cmd/gazctl/cmd/plugin_types.go
+++ b/cmd/gazctl/cmd/plugin_types.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"crypto"
+	"hash/crc32"
 )
 
 // When shard_compose finds the same key in multiple different input sources, it has to select a single value
@@ -17,10 +17,10 @@ func First(key []byte, values [][]byte) []byte {
 // shard_split partitions a shard into multiple shards with smaller keyspaces. In order to do this partitioning, you must
 // specify how you want shards to choose where to put each key. This function takes in a key and the index
 // of the original shard you're processing and outputs an index for the new shard that it will be assigned to.
-type Split func(originalPartition int, key []byte) int
+type Split func(originalPartition int, currentTotalPartitions int, key []byte) int
 
 // Example of a Split function that splits keys in a shard in half arbitrarily
-func Halve(originalPartition int, key []byte) int {
-	h := crypto.MD5.New().Sum(key)
-	return originalPartition + int(h[len(h)-1])%2
+func Halve(originalPartition int, currentTotalPartitions int, key []byte) int {
+	h := crc32.ChecksumIEEE(key)
+	return originalPartition + int(h%2)*currentTotalPartitions
 }

--- a/cmd/gazctl/cmd/shard_split.go
+++ b/cmd/gazctl/cmd/shard_split.go
@@ -111,7 +111,7 @@ func (p Partitioner) Assign(key []byte, value []byte) {
 		// journals, and we won't have to read them starting from the beginning of time.
 		part = p.currentShard
 	} else {
-		part = p.split(p.currentShard, key)
+		part = p.split(p.currentShard, p.currentTotalShards, key)
 	}
 
 	if _, hasKey := p.partitions[part]; !hasKey {

--- a/cmd/gazctl/cmd/shard_split.go
+++ b/cmd/gazctl/cmd/shard_split.go
@@ -25,7 +25,8 @@ in the local output path as pairs of hex-encoded keys and values, in a format th
 
 By default, this function will split a shard in half arbitrarily, by taking a hashmod. You can split shards in a custom way by
 adding a config called "split.plugin" pointing to a .so plugin containing an implementation of the Split type 
-as defined in plugin_types.go.'
+as defined in plugin_types.go. The key containing the latest offset that the shard has read will always be left
+in the current shard, as long as the consumer-journal name provided is the correct.'
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 5 {

--- a/cmd/gazctl/cmd/shard_split.go
+++ b/cmd/gazctl/cmd/shard_split.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"os"
+
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"github.com/LiveRamp/gazette/pkg/consumer"
+	"github.com/LiveRamp/gazette/pkg/journal"
+	rocks "github.com/tecbot/gorocksdb"
+	"io"
+	"strconv"
+)
+
+var shardSplitCmd = &cobra.Command{
+	Use:   "split [rocsksdb-directory] [local-output-path] [current-shard-number] [current-total-shards] [consumer-journal]",
+	Short: "Splits a shard into multiple smaller parts containing a subset of the keyspace.",
+	Long: `Split takes the set of files holding the data in a rocksdb instance and iterates through all keys,
+splitting them into some number of new partitions. The data for each new partition will be written to files
+in the local output path as pairs of hex-encoded keys and values, in a format that can be directly read by shard_compose.
+
+By default, this function will split a shard in half arbitrarily, by taking a hashmod. You can split shards in a custom way by
+adding a config called "split.plugin" pointing to a .so plugin containing an implementation of the Split type 
+as defined in plugin_types.go.'
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 5 {
+			cmd.Usage()
+			log.Fatal("invalid arguments")
+		}
+		var rocksdbPath, outputPath = args[0], args[1]
+		currentShard, err := strconv.Atoi(args[2])
+		if err != nil {
+			log.Fatal("invalid argument: current-shard-number is not an integer")
+		}
+		totalShards, err := strconv.Atoi(args[3])
+		if err != nil {
+			log.Fatal("invalid argument: current-total-shards is not an integer")
+		}
+		var consumerJournal = args[4]
+
+		var opts = rocks.NewDefaultOptions()
+		if plugin := consumerPlugin(); plugin != nil {
+			if initer, _ := plugin.(consumer.OptionsIniter); initer != nil {
+				initer.InitOptions(opts)
+			}
+		}
+
+		var db *rocks.DB
+		var iter iterFunc
+		if db, err = rocks.OpenDbForReadOnly(opts, rocksdbPath, true); err == nil {
+			iter = newDBIterFunc(db)
+		}
+
+		defer func() {
+			db.Close()
+		}()
+
+		plugin := splitPlugin()
+		var splitFunction Split
+		if plugin != nil {
+			splitFunction = plugin
+		} else {
+			splitFunction = Halve
+		}
+
+		partitioner := Partitioner{
+			partitions:         make(map[int]*bufio.Writer),
+			outputDir:          outputPath,
+			split:              splitFunction,
+			currentShard:       currentShard,
+			currentTotalShards: totalShards,
+			consumerJournal:    journal.Name(consumerJournal),
+		}
+
+		var key, value []byte
+		for key, value = nil, nil; err == nil; key, value, err = iter(key, value) {
+			partitioner.Assign(key, value)
+		}
+		if err != io.EOF {
+			log.WithField("err", err).Fatal("failed to split full DB")
+		}
+		err = partitioner.Flush()
+		if err != nil {
+			log.WithField("err", err).Fatal("failed to flush writers")
+		}
+	},
+}
+
+type Partitioner struct {
+	partitions         map[int]*bufio.Writer
+	outputDir          string
+	split              Split
+	currentShard       int
+	currentTotalShards int
+	consumerJournal    journal.Name
+}
+
+func (p Partitioner) Assign(key []byte, value []byte) {
+	if len(key) == 0 || len(value) == 0 {
+		return // filter our nil or garbage keys
+	}
+	var part int
+	if offsetKey := consumer.AppendOffsetKeyEncoding(nil, p.consumerJournal); bytes.Equal(key, offsetKey) {
+		// we want to keep the offset in the current shard. This is so that in the case where we are starting up the consumer
+		// again from the split shard databases, the proper shards will remember at what point new data starts in their root
+		// journals, and we won't have to read them starting from the beginning of time.
+		part = p.currentShard
+	} else {
+		part = p.split(p.currentShard, key)
+	}
+
+	if _, hasKey := p.partitions[part]; !hasKey {
+		outputPath := fmt.Sprintf("%s/shard-compose-%d-%d", p.outputDir, p.currentShard, part)
+		writer, err := os.Create(outputPath)
+		if err != nil {
+			panic("Failed to initialize writer at path " + outputPath)
+		} else {
+			p.partitions[part] = bufio.NewWriter(writer)
+		}
+	}
+	p.partitions[part].WriteString(asHexLine(key, value))
+}
+
+func asHexLine(key []byte, value []byte) string {
+	return "0x" + hex.EncodeToString(key) + " 0x" + hex.EncodeToString(value) + "\n"
+}
+
+func (p Partitioner) Flush() error {
+	for writer := range p.partitions {
+		if err := p.partitions[writer].Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	shardCmd.AddCommand(shardSplitCmd)
+}


### PR DESCRIPTION
@jgraettinger 

I thought I had PRed the shard_split command already, but I guess I only PRed the changes to the shard_compose. This will need some reorganization when gazette 2 fully hits, but here's the shard_split command I used for repartitioning distributions-hashes. I also added a short doc describing how the process of repartitioning works. I'm not sure where the best place is to put it, but I'd imagine there will be other "special case" operations that we want to be able to give some guidance for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/84)
<!-- Reviewable:end -->
