### PR TITLE
Log gazconsumer shard statuses 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,12 +22,6 @@
   version = "v0.5.0"
 
 [[projects]]
-  name = "github.com/DataDog/zstd"
-  packages = ["."]
-  revision = "aebefd9fcb99f22cd691ef778a12ed68f0e6a1ab"
-  version = "v1.3.4"
-
-[[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -264,12 +258,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/golang/snappy"
-  packages = ["."]
-  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
-
-[[projects]]
-  branch = "master"
   name = "github.com/google/btree"
   packages = ["."]
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
@@ -362,21 +350,6 @@
   packages = ["."]
   revision = "2eee05ed794112d45db504eb05aa693efd2b8b09"
   version = "v0.1.0"
-
-[[projects]]
-  name = "github.com/klauspost/compress"
-  packages = [
-    "flate",
-    "gzip"
-  ]
-  revision = "b939724e787a27c0005cabe3f78e7ed7987ac74f"
-  version = "v1.4.0"
-
-[[projects]]
-  name = "github.com/klauspost/cpuid"
-  packages = ["."]
-  revision = "ae7887de9fa5d2db4eaa8174a7eff2c1ac00f2da"
-  version = "v1.1"
 
 [[projects]]
   name = "github.com/kr/fs"
@@ -787,6 +760,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ff48041d7d274e1eef0193e1c5322a59143e8743f396f9a30936ad733ff71a7"
+  inputs-digest = "bb9c569dc67ab645981f23812fc99aca1564c4b3da4315344c12ca78af4aaf1e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,6 +22,12 @@
   version = "v0.5.0"
 
 [[projects]]
+  name = "github.com/DataDog/zstd"
+  packages = ["."]
+  revision = "aebefd9fcb99f22cd691ef778a12ed68f0e6a1ab"
+  version = "v1.3.4"
+
+[[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -258,6 +264,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+
+[[projects]]
+  branch = "master"
   name = "github.com/google/btree"
   packages = ["."]
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
@@ -350,6 +362,21 @@
   packages = ["."]
   revision = "2eee05ed794112d45db504eb05aa693efd2b8b09"
   version = "v0.1.0"
+
+[[projects]]
+  name = "github.com/klauspost/compress"
+  packages = [
+    "flate",
+    "gzip"
+  ]
+  revision = "b939724e787a27c0005cabe3f78e7ed7987ac74f"
+  version = "v1.4.0"
+
+[[projects]]
+  name = "github.com/klauspost/cpuid"
+  packages = ["."]
+  revision = "ae7887de9fa5d2db4eaa8174a7eff2c1ac00f2da"
+  version = "v1.1"
 
 [[projects]]
   name = "github.com/kr/fs"
@@ -760,6 +787,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bb9c569dc67ab645981f23812fc99aca1564c4b3da4315344c12ca78af4aaf1e"
+  inputs-digest = "7ff48041d7d274e1eef0193e1c5322a59143e8743f396f9a30936ad733ff71a7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/gazconsumer/main.go
+++ b/cmd/gazconsumer/main.go
@@ -350,11 +350,15 @@ func getJournalLag(etcdOffsets, writeHeads, readHeads map[string]int64, cdata *c
 			// be less than that amount.)
 			state = "Recovering"
 			readHead = etcdOffsets[journal]
+			log.WithFields(log.Fields{"consumerShardStatus": "Recovering", "journal": journal}).Warn(
+				"Consumer shard is recovering.")
 		} else if readHead == journalNotBeingRead {
 			// The shard is not recovering, but is not busy reading the
 			// journal.
 			state = "NotReading"
 			readHead = etcdOffsets[journal]
+			log.WithFields(log.Fields{"consumerShardStatus": "NotReading", "journal": journal}).Warn(
+				"Consumer shard is not reading the journal.")
 		} else if readHead < etcdOffsets[journal] {
 			// The shard is not recovering and is actively reading. The
 			// offsets stored for this shard in Etcd exceed the ones reported

--- a/cmd/gazconsumer/main.go
+++ b/cmd/gazconsumer/main.go
@@ -350,15 +350,11 @@ func getJournalLag(etcdOffsets, writeHeads, readHeads map[string]int64, cdata *c
 			// be less than that amount.)
 			state = "Recovering"
 			readHead = etcdOffsets[journal]
-			log.WithFields(log.Fields{"consumerShardStatus": "Recovering", "journal": journal}).Warn(
-				"Consumer shard is recovering.")
 		} else if readHead == journalNotBeingRead {
 			// The shard is not recovering, but is not busy reading the
 			// journal.
 			state = "NotReading"
 			readHead = etcdOffsets[journal]
-			log.WithFields(log.Fields{"consumerShardStatus": "NotReading", "journal": journal}).Warn(
-				"Consumer shard is not reading the journal.")
 		} else if readHead < etcdOffsets[journal] {
 			// The shard is not recovering and is actively reading. The
 			// offsets stored for this shard in Etcd exceed the ones reported

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -88,15 +88,15 @@ var (
 	}, []string{"consumer", "journal"})
 )
 
-//func GazconsumerShardStates() []*prometheus.GaugeVec {
-//	return []*prometheus.GaugeVec{
-//		GazconsumerShardIsNotReading,
-//		GazconsumerShardIsNoOwner,
-//		GazconsumerShardIsEtcdAhead,
-//		GazconsumerShardIsOK,
-//		GazconsumerShardIsRecovering,
-//	}
-//}
+func GazconsumerShardStates() []*prometheus.GaugeVec {
+	return []*prometheus.GaugeVec{
+		GazconsumerShardIsNotReading,
+		GazconsumerShardIsNoOwner,
+		GazconsumerShardIsEtcdAhead,
+		GazconsumerShardIsOK,
+		GazconsumerShardIsRecovering,
+	}
+}
 
 func GazconsumerCollectors() []prometheus.Collector {
 	return []prometheus.Collector{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -88,15 +88,15 @@ var (
 	}, []string{"consumer", "journal"})
 )
 
-func GazconsumerShardStates() []*prometheus.GaugeVec {
-	return []*prometheus.GaugeVec{
-		GazconsumerShardIsNotReading,
-		GazconsumerShardIsNoOwner,
-		GazconsumerShardIsEtcdAhead,
-		GazconsumerShardIsOK,
-		GazconsumerShardIsRecovering,
-	}
-}
+//func GazconsumerShardStates() []*prometheus.GaugeVec {
+//	return []*prometheus.GaugeVec{
+//		GazconsumerShardIsNotReading,
+//		GazconsumerShardIsNoOwner,
+//		GazconsumerShardIsEtcdAhead,
+//		GazconsumerShardIsOK,
+//		GazconsumerShardIsRecovering,
+//	}
+//}
 
 func GazconsumerCollectors() []prometheus.Collector {
 	return []prometheus.Collector{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,67 +48,6 @@ func GazetteCollectors() []prometheus.Collector {
 	}
 }
 
-// Keys for gazconsumer metrics.
-const (
-	GazconsumerLagBytesKey          = "gazconsumer_lag_bytes"
-	GazconsumerShardIsRecoveringKey = "gazconsumer_shard_is_recovering"
-	GazconsumerShardIsNotReadingKey = "gazconsumer_shard_is_not_reading"
-	GazconsumerShardIsOKKey         = "gazconsumer_shard_is_ok"
-	GazconsumerShardIsEtcdAheadKey  = "gazconsumer_shard_is_etcd_ahead"
-	GazconsumerShardIsNoOwnerKey    = "gazconsumer_shard_is_no_owner"
-)
-
-// Collectors for gazconsumer metrics.
-var (
-	GazconsumerLagBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: GazconsumerLagBytesKey,
-		Help: "Lag of the consumer on a per shard basis.",
-	}, []string{"consumer"})
-
-	// Binary metrics that indicate whether the shard is in a particular state.
-	GazconsumerShardIsRecovering = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: GazconsumerShardIsRecoveringKey,
-		Help: "Binary value where 1 indicates shard state is 'Recovering', and 0 otherwise.",
-	}, []string{"consumer", "journal"})
-	GazconsumerShardIsNotReading = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: GazconsumerShardIsNotReadingKey,
-		Help: "Binary value where 1 indicates shard state is 'Not Reading', and 0 otherwise.",
-	}, []string{"consumer", "journal"})
-	GazconsumerShardIsOK = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: GazconsumerShardIsOKKey,
-		Help: "Binary value where 1 indicates shard state is 'OK', and 0 otherwise.",
-	}, []string{"consumer", "journal"})
-	GazconsumerShardIsEtcdAhead = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: GazconsumerShardIsEtcdAheadKey,
-		Help: "Binary value where 1 indicates shard state is 'Etcd Ahead', and 0 otherwise.",
-	}, []string{"consumer", "journal"})
-	GazconsumerShardIsNoOwner = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: GazconsumerShardIsNoOwnerKey,
-		Help: "Binary value where 1 indicates shard state is 'No Owner', and 0 otherwise.",
-	}, []string{"consumer", "journal"})
-)
-
-func GazconsumerShardStates() []*prometheus.GaugeVec {
-	return []*prometheus.GaugeVec{
-		GazconsumerShardIsNotReading,
-		GazconsumerShardIsNoOwner,
-		GazconsumerShardIsEtcdAhead,
-		GazconsumerShardIsOK,
-		GazconsumerShardIsRecovering,
-	}
-}
-
-func GazconsumerCollectors() []prometheus.Collector {
-	return []prometheus.Collector{
-		GazconsumerLagBytes,
-		GazconsumerShardIsRecovering,
-		GazconsumerShardIsNotReading,
-		GazconsumerShardIsOK,
-		GazconsumerShardIsNoOwner,
-		GazconsumerShardIsEtcdAhead,
-	}
-}
-
 // Keys for gazretention metrics.
 const (
 	GazretentionDeletedBytesTotalKey      = "gazretention_deleted_bytes_total"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -50,7 +50,12 @@ func GazetteCollectors() []prometheus.Collector {
 
 // Keys for gazconsumer metrics.
 const (
-	GazconsumerLagBytesKey = "gazconsumer_lag_bytes"
+	GazconsumerLagBytesKey          = "gazconsumer_lag_bytes"
+	GazconsumerShardIsRecoveringKey = "gazconsumer_shard_is_recovering"
+	GazconsumerShardIsNotReadingKey = "gazconsumer_shard_is_not_reading"
+	GazconsumerShardIsOKKey         = "gazconsumer_shard_is_ok"
+	GazconsumerShardIsEtcdAheadKey  = "gazconsumer_shard_is_etcd_ahead"
+	GazconsumerShardIsNoOwnerKey    = "gazconsumer_shard_is_no_owner"
 )
 
 // Collectors for gazconsumer metrics.
@@ -59,10 +64,49 @@ var (
 		Name: GazconsumerLagBytesKey,
 		Help: "Lag of the consumer on a per shard basis.",
 	}, []string{"consumer"})
+
+	// Binary metrics that indicate whether the shard is in a particular state.
+	GazconsumerShardIsRecovering = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: GazconsumerShardIsRecoveringKey,
+		Help: "Binary value where 1 indicates shard state is 'Recovering', and 0 otherwise.",
+	}, []string{"consumer", "journal"})
+	GazconsumerShardIsNotReading = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: GazconsumerShardIsNotReadingKey,
+		Help: "Binary value where 1 indicates shard state is 'Not Reading', and 0 otherwise.",
+	}, []string{"consumer", "journal"})
+	GazconsumerShardIsOK = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: GazconsumerShardIsOKKey,
+		Help: "Binary value where 1 indicates shard state is 'OK', and 0 otherwise.",
+	}, []string{"consumer", "journal"})
+	GazconsumerShardIsEtcdAhead = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: GazconsumerShardIsEtcdAheadKey,
+		Help: "Binary value where 1 indicates shard state is 'Etcd Ahead', and 0 otherwise.",
+	}, []string{"consumer", "journal"})
+	GazconsumerShardIsNoOwner = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: GazconsumerShardIsNoOwnerKey,
+		Help: "Binary value where 1 indicates shard state is 'No Owner', and 0 otherwise.",
+	}, []string{"consumer", "journal"})
 )
 
+//func GazconsumerShardStates() []*prometheus.GaugeVec {
+//	return []*prometheus.GaugeVec{
+//		GazconsumerShardIsNotReading,
+//		GazconsumerShardIsNoOwner,
+//		GazconsumerShardIsEtcdAhead,
+//		GazconsumerShardIsOK,
+//		GazconsumerShardIsRecovering,
+//	}
+//}
+
 func GazconsumerCollectors() []prometheus.Collector {
-	return []prometheus.Collector{GazconsumerLagBytes}
+	return []prometheus.Collector{
+		GazconsumerLagBytes,
+		GazconsumerShardIsRecovering,
+		GazconsumerShardIsNotReading,
+		GazconsumerShardIsOK,
+		GazconsumerShardIsNoOwner,
+		GazconsumerShardIsEtcdAhead,
+	}
 }
 
 // Keys for gazretention metrics.


### PR DESCRIPTION
We've run into problems where some of our consumer shards stay in the `Recovering` or `NotReading` state (as indicated by `gazconsumer`) for a long time, without being detected. This can occur for a number of reasons—underlying data loss in the journals, corrupted hints, running out of disk space, etc—which we have to manually solve before the shards can go back to the `OK` state. As such, we want to enable better monitoring of when consumer shards enter a different state and how long they stay there, so that we can configure our alerts accordingly and respond more promptly.

This initial approach registers one Prometheus gauge-type metric for each possible consumer shard state, where a 1 indicates that the shard is in that state and 0 if it is not. 

Other approaches we considered and ruled out were:
- Logging non-`OK` states as `Warn` statements (pushing the metrics to Prometheus would make it easier to visualize the data as a time-series plot and enable alerting)
- Having only one new Prometheus gauge-type metric but `N` possible values type for that metric, where `N` is the number of possible consumer shard statuses (it would sacrifice clarity if we relied on some arbitrary mapping of numbers to statuses)
- Have the metrics be of type counter rather than gauge, and increment each metric each time the shard is observed to be in that state (we thought doing 0/1 would be clearer than having some monotonically increasing number whose value has no real meaning).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/85)
<!-- Reviewable:end -->
