### PR TITLE
etcdtest,keyspace,allocator: add & use etcd test server package

### DIFF
--- a/v2/pkg/allocator/alloc_state.go
+++ b/v2/pkg/allocator/alloc_state.go
@@ -1,4 +1,4 @@
-package v3_allocator
+package allocator
 
 import (
 	"hash/crc64"
@@ -8,7 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/LiveRamp/gazette/pkg/keyspace"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
 )
 
 // State is an extracted representation of the allocator KeySpace. Clients may
@@ -56,14 +56,18 @@ func NewObservedState(ks *keyspace.KeySpace, localKey string) *State {
 // observe extracts a current State representation from the KeySpace,
 // pivoted around the Member instance identified by |LocalKey|.
 func (s *State) observe() {
-	*s = State{
-		KS:       s.KS,
-		LocalKey: s.LocalKey,
 
-		Members:     s.KS.Prefixed(s.KS.Root + MembersPrefix),
-		Items:       s.KS.Prefixed(s.KS.Root + ItemsPrefix),
-		Assignments: s.KS.Prefixed(s.KS.Root + AssignmentsPrefix),
-	}
+	// Re-init fields of State in preparation for extraction from the KeySpace.
+	// KS & LocalKey are not modified, and may be concurrently accessed.
+	s.Members = s.KS.Prefixed(s.KS.Root + MembersPrefix)
+	s.Items = s.KS.Prefixed(s.KS.Root + ItemsPrefix)
+	s.Assignments = s.KS.Prefixed(s.KS.Root + AssignmentsPrefix)
+	s.LocalMemberInd = -1
+	s.LocalItems = s.LocalItems[:0]
+	s.Zones = s.Zones[:0]
+	s.MemberSlots = 0
+	s.ItemSlots = 0
+	s.NetworkHash = 0
 	s.MemberTotalCount = make([]int, len(s.Members))
 	s.MemberPrimaryCount = make([]int, len(s.Members))
 
@@ -99,29 +103,29 @@ func (s *State) observe() {
 	//   * Initialize |NetworkHash|.
 	//   * Collect Items and Assignments which map to the |LocalKey| Member.
 	//   * Accumulate per-Member counts of primary and total Assignments.
-	var it = leftJoin{
-		lenL: len(s.Items),
-		lenR: len(s.Assignments),
-		compare: func(l, r int) int {
+	var it = LeftJoin{
+		LenL: len(s.Items),
+		LenR: len(s.Assignments),
+		Compare: func(l, r int) int {
 			return strings.Compare(itemAt(s.Items, l).ID, assignmentAt(s.Assignments, r).ItemID)
 		},
 	}
-	for cur, ok := it.next(); ok; cur, ok = it.next() {
-		var item = itemAt(s.Items, cur.left)
+	for cur, ok := it.Next(); ok; cur, ok = it.Next() {
+		var item = itemAt(s.Items, cur.Left)
 		var r = item.DesiredReplication()
 
 		s.ItemSlots += r
-		s.NetworkHash = foldCRC(s.NetworkHash, s.Items[cur.left].Raw.Key, r)
+		s.NetworkHash = foldCRC(s.NetworkHash, s.Items[cur.Left].Raw.Key, r)
 
-		for r := cur.rightBegin; r != cur.rightEnd; r++ {
+		for r := cur.RightBegin; r != cur.RightEnd; r++ {
 			var a = assignmentAt(s.Assignments, r)
 			var key = MemberKey(s.KS, a.MemberZone, a.MemberSuffix)
 
 			if key == s.LocalKey {
 				s.LocalItems = append(s.LocalItems, LocalItem{
-					Item:        s.Items[cur.left],
-					Assignments: s.Assignments[cur.rightBegin:cur.rightEnd],
-					Index:       r - cur.rightBegin,
+					Item:        s.Items[cur.Left],
+					Assignments: s.Assignments[cur.RightBegin:cur.RightEnd],
+					Index:       r - cur.RightBegin,
 				})
 			}
 			if ind, found := s.Members.Search(key); found {

--- a/v2/pkg/allocator/alloc_state_test.go
+++ b/v2/pkg/allocator/alloc_state_test.go
@@ -1,16 +1,18 @@
-package v3_allocator
+package allocator
 
 import (
 	"context"
 	"math"
 
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
 	gc "github.com/go-check/check"
 )
 
 type AllocStateSuite struct{}
 
 func (s *AllocStateSuite) TestExtractOverFixture(c *gc.C) {
-	var client, ctx = etcdCluster.RandClient(), context.Background()
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
 	buildAllocKeySpaceFixture(c, ctx, client)
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
@@ -76,7 +78,8 @@ func (s *AllocStateSuite) TestExtractOverFixture(c *gc.C) {
 }
 
 func (s *AllocStateSuite) TestLeaderSelection(c *gc.C) {
-	var client, ctx = etcdCluster.RandClient(), context.Background()
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
 	// Note the fixture adds keys in random order (the leader may differ each run).
 	buildAllocKeySpaceFixture(c, ctx, client)
 
@@ -100,8 +103,9 @@ func (s *AllocStateSuite) TestLeaderSelection(c *gc.C) {
 }
 
 func (s *AllocStateSuite) TestExitCondition(c *gc.C) {
-	var client, ctx = etcdCluster.RandClient(), context.Background()
+	var client, ctx = etcdtest.TestClient(), context.Background()
 	buildAllocKeySpaceFixture(c, ctx, client)
+	defer etcdtest.Cleanup()
 
 	var _, err = client.Put(ctx, "/root/members/us-east#allowed-to-exit", `{"R": 0}`)
 	c.Assert(err, gc.IsNil)
@@ -124,8 +128,9 @@ func (s *AllocStateSuite) TestExitCondition(c *gc.C) {
 }
 
 func (s *AllocStateSuite) TestLoadRatio(c *gc.C) {
-	var client, ctx = etcdCluster.RandClient(), context.Background()
+	var client, ctx = etcdtest.TestClient(), context.Background()
 	buildAllocKeySpaceFixture(c, ctx, client)
+	defer etcdtest.Cleanup()
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
 	var state = NewObservedState(ks, MemberKey(ks, "us-east", "foo"))

--- a/v2/pkg/allocator/allocator.go
+++ b/v2/pkg/allocator/allocator.go
@@ -1,4 +1,4 @@
-package v3_allocator
+package allocator
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/LiveRamp/gazette/pkg/keyspace"
-	"github.com/LiveRamp/gazette/pkg/v3.allocator/push_relabel"
+	"github.com/LiveRamp/gazette/v2/pkg/allocator/push_relabel"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
 )
 
 type AllocateArgs struct {
@@ -20,9 +20,8 @@ type AllocateArgs struct {
 	Etcd *clientv3.Client
 	// Allocator state, which is derived from a Watched KeySpace.
 	State *State
-
-	// testHook is an optional testing hook, invoked after each convergence round.
-	testHook func(round int, isIdle bool)
+	// TestHook is an optional testing hook, invoked after each convergence round.
+	TestHook func(round int, isIdle bool)
 }
 
 // Allocate observes the Allocator KeySpace, and if this Allocator instance is
@@ -107,8 +106,8 @@ func Allocate(args AllocateArgs) error {
 				log.WithFields(log.Fields{"err": err, "round": round, "rev": ks.Header.Revision}).
 					Warn("converge iteration failed (will retry)")
 			} else {
-				if args.testHook != nil {
-					args.testHook(round, ks.Header.Revision == txnResponse.Header.Revision)
+				if args.TestHook != nil {
+					args.TestHook(round, ks.Header.Revision == txnResponse.Header.Revision)
 				}
 				round++
 			}
@@ -127,36 +126,39 @@ func Allocate(args AllocateArgs) error {
 	}
 }
 
-// converge identifies and applies incremental changes which bring the current
-// state closer to the |desired| state, subject to Item and Member constraints.
+// converge identifies and applies allowed incremental changes which bring the
+// current state closer to the |desired| state. A change is allowed iff it does
+// not cause any Item or Member replication constraints to be violated (eg, by
+// leaving an Item with too few consistent replicas, or a Member with too many
+// assigned Items).
 func converge(txn checkpointTxn, as *State, desired []Assignment) error {
 	var itemState = itemState{global: as}
-	var lastCRE int // cur.rightEnd of the previous iteration.
+	var lastCRE int // cur.RightEnd of the previous iteration.
 
 	// Walk Items, joined with their current Assignments. Simultaneously walk
 	// |desired| Assignments to join against those as well.
-	var it = leftJoin{
-		lenL: len(as.Items),
-		lenR: len(as.Assignments),
-		compare: func(l, r int) int {
+	var it = LeftJoin{
+		LenL: len(as.Items),
+		LenR: len(as.Assignments),
+		Compare: func(l, r int) int {
 			return strings.Compare(itemAt(as.Items, l).ID, assignmentAt(as.Assignments, r).ItemID)
 		},
 	}
-	for cur, ok := it.next(); ok; cur, ok = it.next() {
+	for cur, ok := it.Next(); ok; cur, ok = it.Next() {
 		// Remove any Assignments skipped between the last cursor iteration, and this
-		// one. They must not have an Associated Item (eg, it was deleted).
-		if err := removeDeadAssignments(txn, as.KS, as.Assignments[lastCRE:cur.rightBegin]); err != nil {
+		// one. They must not have an associated Item (eg, it was deleted).
+		if err := removeDeadAssignments(txn, as.KS, as.Assignments[lastCRE:cur.RightBegin]); err != nil {
 			return err
 		}
-		lastCRE = cur.rightEnd
+		lastCRE = cur.RightEnd
 
-		var itemID, limit = itemAt(as.Items, cur.left).ID, 0
+		var itemID, limit = itemAt(as.Items, cur.Left).ID, 0
 		// Determine leading sub-slice of |desired| which are Assignments of |itemID|.
 		for ; limit != len(desired) && desired[limit].ItemID == itemID; limit++ {
 		}
 
 		// Initialize |itemState|, computing the delta of current and |desired| Item Assignments.
-		itemState.init(cur.left, as.Assignments[cur.rightBegin:cur.rightEnd], desired[:limit])
+		itemState.init(cur.Left, as.Assignments[cur.RightBegin:cur.RightEnd], desired[:limit])
 		if err := itemState.constrainAndBuildOps(txn); err != nil {
 			return err
 		}
@@ -171,6 +173,7 @@ func converge(txn checkpointTxn, as *State, desired []Assignment) error {
 }
 
 // removeDeadAssignments removes Assignments |asn|, after verifying each has no associated Item.
+// This is a sanity check that our removal hasn't raced a re-creation of the Item.
 func removeDeadAssignments(txn checkpointTxn, ks *keyspace.KeySpace, asn keyspace.KeyValues) error {
 	for len(asn) != 0 {
 		var itemID, limit = assignmentAt(asn, 0).ItemID, 1
@@ -237,6 +240,9 @@ type batchedTxn struct {
 // apply |fixedCmps| on every underlying Txn it issues (eg, they needn't be added
 // with If to each checkpoint).
 func newBatchedTxn(ctx context.Context, kv clientv3.KV, fixedCmps ...clientv3.Cmp) *batchedTxn {
+	if len(fixedCmps) >= maxTxnOps {
+		panic("too many fixedCmps")
+	}
 	return &batchedTxn{
 		txnDo: func(txn clientv3.Op) (*clientv3.TxnResponse, error) {
 			if r, err := kv.Do(ctx, txn); err != nil {

--- a/v2/pkg/allocator/allocator_key_space.go
+++ b/v2/pkg/allocator/allocator_key_space.go
@@ -1,4 +1,4 @@
-package v3_allocator
+package allocator
 
 import (
 	"bytes"
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/LiveRamp/gazette/pkg/keyspace"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 )
 
@@ -214,54 +214,54 @@ func compareAssignment(l, r Assignment) int {
 	return 0
 }
 
-// leftJoin performs a left join of two comparable, index-able, and ordered collections.
-type leftJoin struct {
+// LeftJoin performs a Left join of two comparable, index-able, and ordered collections.
+type LeftJoin struct {
 	// length of the collections.
-	lenL, lenR int
-	// compare returns -1 if |l| orders before |r|, 0 if they are equal,
+	LenL, LenR int
+	// Compare returns -1 if |l| orders before |r|, 0 if they are equal,
 	// and 1 if |l| is greater.
-	compare func(l, r int) int
+	Compare func(l, r int) int
 
-	cursor
+	LeftJoinCursor
 }
 
-// cursor is a leftJoin result row, relating a |left| index with a
-// [rightBegin, rightEnd) range of indices comparing as equal.
-type cursor struct {
-	left, rightBegin, rightEnd int
+// LeftJoinCursor is a LeftJoin result row, relating a |Left| index with a
+// [RightBegin, RightEnd) range of indices comparing as equal.
+type LeftJoinCursor struct {
+	Left, RightBegin, RightEnd int
 }
 
 // next returns the next cursor of the join and true, or if no rows remain in
 // the join, a zero-valued cursor and false.
-func (j *leftJoin) next() (cursor, bool) {
-	for j.left < j.lenL {
+func (j *LeftJoin) Next() (LeftJoinCursor, bool) {
+	for j.Left < j.LenL {
 		var c int
 
-		if j.rightEnd == j.lenR {
+		if j.RightEnd == j.LenR {
 			c = -1
 		} else {
-			c = j.compare(j.left, j.rightEnd)
+			c = j.Compare(j.Left, j.RightEnd)
 		}
 
 		switch c {
 		case -1:
-			// Left-hand entry is before next right-hand entry. Return left-hand entry with accumulated right-hand entries.
-			var cur = j.cursor
-			// Step to next left-hand entry. Reset right-hand range to iterate over the accumulated entries again.
-			j.left, j.rightEnd = j.left+1, j.rightBegin
+			// Left-hand entry is before next right-hand entry. Return Left-hand entry with accumulated right-hand entries.
+			var cur = j.LeftJoinCursor
+			// Step to next Left-hand entry. Reset right-hand range to iterate over the accumulated entries again.
+			j.Left, j.RightEnd = j.Left+1, j.RightBegin
 			return cur, true
 		case 0:
 			// Left-hand entry matches right-hand entry. Accumulate and step to next right-hand entry.
-			j.rightEnd++
+			j.RightEnd++
 		case 1:
 			// Left-hand entry is greater than right-hand entry. Skip right-hand entry.
-			if j.rightBegin != j.rightEnd {
-				panic("leftJoin inputs are not ordered")
+			if j.RightBegin != j.RightEnd {
+				panic("LeftJoin inputs are not ordered")
 			}
-			j.rightEnd, j.rightBegin = j.rightEnd+1, j.rightEnd+1
+			j.RightEnd, j.RightBegin = j.RightEnd+1, j.RightEnd+1
 		}
 	}
-	return cursor{}, false
+	return LeftJoinCursor{}, false
 }
 
 func assertAboveSep(s string) {

--- a/v2/pkg/allocator/announce_test.go
+++ b/v2/pkg/allocator/announce_test.go
@@ -1,28 +1,28 @@
-package v3_allocator
+package allocator
 
 import (
 	"context"
 	"time"
 
-	"github.com/coreos/etcd/clientv3/concurrency"
 	gc "github.com/go-check/check"
+	"github.com/coreos/etcd/clientv3/concurrency"
+
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
 )
 
 type AnnounceSuite struct{}
 
 func (s *AnnounceSuite) TestAnnounceUpdateAndExpire(c *gc.C) {
-	var client = etcdCluster.RandClient()
-	var ctx = context.Background()
+	var client = etcdtest.TestClient()
+	defer etcdtest.Cleanup()
 	const key = "/announce/key"
 
 	var session, err = concurrency.NewSession(client, concurrency.WithTTL(5))
 	c.Check(err, gc.IsNil)
 
-	a, err := Announce(ctx, client, key, "val-1", session.Lease())
-	c.Check(err, gc.IsNil)
-
-	c.Check(a.Update(ctx, "val-2"), gc.IsNil)
-	c.Check(a.Update(ctx, "val-3"), gc.IsNil)
+	var a = Announce(client, key, "val-1", session.Lease())
+	c.Check(a.Update("val-2"), gc.IsNil)
+	c.Check(a.Update("val-3"), gc.IsNil)
 
 	c.Check(session.Close(), gc.IsNil)
 
@@ -30,33 +30,41 @@ func (s *AnnounceSuite) TestAnnounceUpdateAndExpire(c *gc.C) {
 	c.Check(err, gc.IsNil)
 	c.Check(resp.Count, gc.Equals, int64(0))
 
-	c.Check(a.Update(ctx, "val-4"), gc.ErrorMatches,
+	c.Check(a.Update("val-4"), gc.ErrorMatches,
 		`key modified or deleted externally \(expected revision \d+\)`)
 }
 
 func (s *AnnounceSuite) TestAnnounceConflict(c *gc.C) {
-	var client = etcdCluster.RandClient()
-	var ctx, cancel = context.WithCancel(context.Background())
+	var client = etcdtest.TestClient()
+	defer etcdtest.Cleanup()
 	const key = "/announce/key"
 
-	var session, err = concurrency.NewSession(client, concurrency.WithTTL(5))
+	var session1, err = concurrency.NewSession(client, concurrency.WithTTL(5))
 	c.Check(err, gc.IsNil)
-	defer session.Close()
 
-	_, err = Announce(ctx, client, key, "val-other", session.Lease())
-	c.Check(err, gc.IsNil)
+	Announce(client, key, "value1", session1.Lease())
 
 	// Temporarily set the retry interval to a very short duration.
 	defer func(d time.Duration) {
 		announceConflictRetryInterval = d
 	}(announceConflictRetryInterval)
 
-	// Expect that Announce retries until the context is cancelled.
 	announceConflictRetryInterval = time.Millisecond
-	time.AfterFunc(10*announceConflictRetryInterval, cancel)
 
-	_, err = Announce(ctx, client, key, "val-other", session.Lease())
-	c.Check(err, gc.Equals, context.Canceled)
+	session2, err := concurrency.NewSession(client, concurrency.WithTTL(5))
+	c.Check(err, gc.IsNil)
+	defer session2.Close()
+
+	// Expect that Announce retries until the prior lease is revoked,
+	// and it can announce its value.
+	time.AfterFunc(10*announceConflictRetryInterval, func() {
+		c.Check(session1.Close(), gc.IsNil) // Prior key is removed with lease.
+	})
+	Announce(client, key, "value2", session2.Lease())
+
+	resp, err := client.Get(context.Background(), key)
+	c.Check(err, gc.IsNil)
+	c.Check(string(resp.Kvs[0].Value), gc.Equals, "value2")
 }
 
 var _ = gc.Suite(&AnnounceSuite{})

--- a/v2/pkg/allocator/benchmark_test.go
+++ b/v2/pkg/allocator/benchmark_test.go
@@ -1,29 +1,22 @@
-package v3_allocator
+package allocator
 
 import (
 	"context"
 	"fmt"
 	"testing"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
 	gc "github.com/go-check/check"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/LiveRamp/gazette/pkg/keyspace"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
 )
 
 func BenchmarkAll(b *testing.B) {
-	var fakeT testing.T
-	etcdCluster = integration.NewClusterV3(&fakeT, &integration.ClusterConfig{Size: 1})
-
-	var client = etcdCluster.RandClient()
-
 	b.Run("simulated-deploy", func(b *testing.B) {
-		benchmarkSimulatedDeploy(b, client)
+		benchmarkSimulatedDeploy(b)
 	})
-	etcdCluster.Terminate(&fakeT)
 }
 
 type BenchmarkHealthSuite struct{}
@@ -31,20 +24,19 @@ type BenchmarkHealthSuite struct{}
 // TestBenchmarkHealth runs benchmarks with a small N to ensure they don't bit rot.
 func (s *BenchmarkHealthSuite) TestBenchmarkHealth(c *gc.C) {
 	var fakeB = testing.B{N: 50}
-	var client = etcdCluster.RandClient()
 
-	benchmarkSimulatedDeploy(&fakeB, client)
+	benchmarkSimulatedDeploy(&fakeB)
 }
 
 var _ = gc.Suite(&BenchmarkHealthSuite{})
 
-func benchmarkSimulatedDeploy(b *testing.B, client *clientv3.Client) {
+func benchmarkSimulatedDeploy(b *testing.B) {
+	var client = etcdtest.TestClient()
+	defer etcdtest.Cleanup()
+
 	var ctx, _ = context.WithCancel(context.Background())
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
 	var state = NewObservedState(ks, MemberKey(ks, "zone-b", "leader"))
-
-	var _, err = client.Delete(ctx, "", clientv3.WithPrefix())
-	assert.NoError(b, err)
 
 	var NItems = b.N
 
@@ -134,7 +126,7 @@ func benchmarkSimulatedDeploy(b *testing.B, client *clientv3.Client) {
 		Context:  ctx,
 		Etcd:     client,
 		State:    state,
-		testHook: testHook,
+		TestHook: testHook,
 	}))
 }
 

--- a/v2/pkg/allocator/doc.go
+++ b/v2/pkg/allocator/doc.go
@@ -6,4 +6,4 @@
 // Allocator coordinates through Etcd, and uses a greedy, incremental maximum-
 // flow solver to quickly determine minimal re-Assignments which best balance
 // Items across Members (subject to constraints).
-package v3_allocator
+package allocator

--- a/v2/pkg/allocator/flow_network_test.go
+++ b/v2/pkg/allocator/flow_network_test.go
@@ -1,18 +1,19 @@
-package v3_allocator
+package allocator
 
 import (
 	"context"
 
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
 	gc "github.com/go-check/check"
 
-	pr "github.com/LiveRamp/gazette/pkg/v3.allocator/push_relabel"
+	pr "github.com/LiveRamp/gazette/v2/pkg/allocator/push_relabel"
 )
 
 type FlowNetworkSuite struct{}
 
 func (s *FlowNetworkSuite) TestFlowOverSimpleFixture(c *gc.C) {
-	var client = etcdCluster.RandClient()
-	var ctx = context.Background()
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
 	buildAllocKeySpaceFixture(c, ctx, client)
 
 	var ks = NewAllocatorKeySpace("/root", testAllocDecoder{})

--- a/v2/pkg/allocator/item_state.go
+++ b/v2/pkg/allocator/item_state.go
@@ -1,11 +1,11 @@
-package v3_allocator
+package allocator
 
 import (
 	"sort"
 
 	"github.com/coreos/etcd/clientv3"
 
-	"github.com/LiveRamp/gazette/pkg/keyspace"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
 )
 
 // itemState is an extracted representation of an Item and a collection of

--- a/v2/pkg/allocator/item_state_test.go
+++ b/v2/pkg/allocator/item_state_test.go
@@ -1,12 +1,13 @@
-package v3_allocator
+package allocator
 
 import (
 	"context"
 
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
 	"github.com/coreos/etcd/clientv3"
 	gc "github.com/go-check/check"
 
-	"github.com/LiveRamp/gazette/pkg/keyspace"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
 )
 
 type ItemStateSuite struct{}
@@ -404,11 +405,8 @@ func (s *ItemStateSuite) TestBuildPackOps(c *gc.C) {
 }
 
 func buildItemStateFixture(c *gc.C, fixture map[string]string) (*keyspace.KeySpace, *itemState) {
-	var client = etcdCluster.RandClient()
-	var ctx = context.Background()
-
-	var _, err = client.Delete(ctx, "", clientv3.WithPrefix())
-	c.Assert(err, gc.IsNil)
+	var client, ctx = etcdtest.TestClient(), context.Background()
+	defer etcdtest.Cleanup()
 
 	for k, v := range fixture {
 		var _, err = client.Put(ctx, k, v)

--- a/v2/pkg/allocator/scenarios_test.go
+++ b/v2/pkg/allocator/scenarios_test.go
@@ -1,12 +1,13 @@
-package v3_allocator
+package allocator
 
 import (
 	"context"
 
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
 	"github.com/coreos/etcd/clientv3"
 	gc "github.com/go-check/check"
 
-	"github.com/LiveRamp/gazette/pkg/keyspace"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
 )
 
 type ScenariosSuite struct {
@@ -16,10 +17,12 @@ type ScenariosSuite struct {
 }
 
 func (s *ScenariosSuite) SetUpSuite(c *gc.C) {
-	s.client = etcdCluster.RandClient()
+	s.client = etcdtest.TestClient()
 	s.ctx = context.Background()
 	s.ks = NewAllocatorKeySpace("/root", testAllocDecoder{})
 }
+
+func (s *ScenariosSuite) TearDownSuite(c *gc.C) { etcdtest.Cleanup() }
 
 func (s *ScenariosSuite) SetUpTest(c *gc.C) {
 	var _, err = s.client.Delete(s.ctx, "", clientv3.WithPrefix())
@@ -650,7 +653,7 @@ func serveUntilIdle(c *gc.C, ctx context.Context, client *clientv3.Client, ks *k
 		Context: ctx,
 		Etcd:    client,
 		State:   state,
-		testHook: func(round int, idle bool) {
+		TestHook: func(round int, idle bool) {
 			if idle {
 				result = round // Preserve and return the round on which the Allocator became idle.
 				cancel()

--- a/v2/pkg/etcdtest/etcd.go
+++ b/v2/pkg/etcdtest/etcd.go
@@ -1,0 +1,71 @@
+// Package etcdtest provides test support for obtaining a client to an Etcd server.
+//
+package etcdtest
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/embed"
+	"github.com/coreos/etcd/etcdserver/api/v3client"
+)
+
+func TestClient() *clientv3.Client {
+	var client = v3client.New(embedEtcd.Server)
+
+	var resp, err = client.Get(context.Background(), "", clientv3.WithPrefix(), clientv3.WithLimit(5))
+	if err != nil {
+		log.Fatal(err)
+	} else if len(resp.Kvs) != 0 {
+		log.Fatalf("etcd not empty; did a previous test not clean up?\n%+v", resp)
+	}
+
+	return client
+}
+
+func Cleanup() {
+	if _, err := v3client.New(embedEtcd.Server).Delete(context.Background(), "", clientv3.WithPrefix()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func init() {
+	var cfg = embed.NewConfig()
+	cfg.Dir = filepath.Join(os.TempDir(), "etcdtest.etcd", filepath.Base(os.Args[0]))
+	cfg.LPUrls = nil
+	cfg.LCUrls = nil
+
+	_ = os.RemoveAll(cfg.Dir)
+
+	// Squelch non-error logging from etcdserver, to not pollute test outputs.
+	cfg.LogPkgLevels = strings.Join([]string{
+		"auth=ERROR",
+		"embed=ERROR",
+		"etcdserver/api=ERROR",
+		"etcdserver/membership=ERROR",
+		"etcdserver=ERROR",
+		"raft=ERROR",
+		"wal=ERROR",
+	}, ",")
+	cfg.SetupLogging()
+
+	var err error
+	if embedEtcd, err = embed.StartEtcd(cfg); err != nil {
+		log.Fatal(err)
+	}
+
+	select {
+	case <-embedEtcd.Server.ReadyNotify():
+	case <-time.After(60 * time.Second):
+		embedEtcd.Server.Stop()
+		log.Fatal("Etcd server took > 1min to start")
+	}
+	go func() { log.Fatal(<-embedEtcd.Err()) }()
+}
+
+var embedEtcd *embed.Etcd

--- a/v2/pkg/keyspace/key_space_test.go
+++ b/v2/pkg/keyspace/key_space_test.go
@@ -7,21 +7,21 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	epb "github.com/coreos/etcd/etcdserver/etcdserverpb"
-	"github.com/coreos/etcd/integration"
 	gc "github.com/go-check/check"
+
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
 )
 
 type KeySpaceSuite struct{}
 
 func (s *KeySpaceSuite) TestLoadAndWatch(c *gc.C) {
-	var client = etcdCluster.RandClient()
+	var client = etcdtest.TestClient()
 	var ctx, cancel = context.WithCancel(context.Background())
 
-	var _, err = client.Delete(ctx, "", clientv3.WithPrefix())
-	c.Assert(err, gc.IsNil)
+	defer etcdtest.Cleanup()
 
 	// Fix some initial keys and values.
-	_, err = client.Put(ctx, "/one", "1")
+	_, err := client.Put(ctx, "/one", "1")
 	c.Assert(err, gc.IsNil)
 	_, err = client.Put(ctx, "/foo", "invalid value is logged and skipped")
 	c.Assert(err, gc.IsNil)
@@ -116,7 +116,7 @@ func (s *KeySpaceSuite) TestWatchResponseApply(c *gc.C) {
 	verifyDecodedKeyValues(c, ks.KeyValues,
 		map[string]int{"/some/key": 99, "/other/key": 100})
 
-	// Key/value inconsistencies are logged but returned as an error.
+	// Key/value inconsistencies are logged but not returned as an error.
 	resp = []clientv3.WatchResponse{{
 		Header: epb.ResponseHeader{ClusterId: 9999, Revision: 11},
 		Events: []*clientv3.Event{
@@ -259,13 +259,6 @@ func (s *KeySpaceSuite) TestWaitForRevision(c *gc.C) {
 	c.Check(ks.WaitForRevision(ctx, 101), gc.Equals, context.Canceled)
 }
 
-var (
-	_           = gc.Suite(&KeySpaceSuite{})
-	etcdCluster *integration.ClusterV3
-)
+var _ = gc.Suite(&KeySpaceSuite{})
 
-func Test(t *testing.T) {
-	etcdCluster = integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
-	gc.TestingT(t)
-	etcdCluster.Terminate(t)
-}
+func Test(t *testing.T) { gc.TestingT(t) }


### PR DESCRIPTION
Rename v3_allocator => allocator, and refactor it and keyspace to
both use etcdtest. KeySpace also now supports a set-able WatchDelay
(speeds up tests), and fix data races detected with -race.

Issue #47