### PR TITLE
broker: runtime and gRPC JournalServer

### DIFF
--- a/v2/pkg/broker/append_api.go
+++ b/v2/pkg/broker/append_api.go
@@ -1,0 +1,286 @@
+package broker
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"hash"
+	"io"
+
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// Append dispatches the JournalServer.Append API.
+func (srv *Service) Append(stream pb.Journal_AppendServer) error {
+	var req, err = stream.Recv()
+	if err != nil {
+		return err
+	} else if err = req.Validate(); err != nil {
+		return err
+	}
+
+	var rev int64
+
+	for {
+		var res resolution
+		res, err = srv.resolver.resolve(resolveArgs{
+			ctx:                   stream.Context(),
+			journal:               req.Journal,
+			mayProxy:              !req.DoNotProxy,
+			requirePrimary:        true,
+			requireFullAssignment: true,
+			minEtcdRevision:       rev,
+			proxyHeader:           req.Header,
+		})
+
+		if err != nil {
+			break
+		} else if res.status != pb.Status_OK {
+			err = stream.SendAndClose(&pb.AppendResponse{
+				Status: res.status,
+				Header: &res.Header,
+			})
+			break
+		} else if res.replica == nil {
+			req.Header = &res.Header
+			err = proxyAppend(stream, req, srv.jc)
+			break
+		}
+
+		var pln *pipeline
+		if pln, rev, err = acquirePipeline(stream.Context(), res.replica, res.Header, srv.jc); err != nil {
+			break
+		} else if rev != 0 {
+			// A peer told us of a future & non-equivalent Route revision.
+			// Continue to attempt to start a pipeline again at |rev|.
+		} else {
+			err = serveAppend(stream, pln, res.journalSpec, res.replica.pipelineCh)
+			break
+		}
+	}
+
+	if err != nil {
+		log.WithFields(log.Fields{"err": err, "req": req}).Warn("failed to serve Append")
+		return err
+	}
+	return nil
+}
+
+// proxyAppend forwards an AppendRequest to a resolved peer broker.
+func proxyAppend(stream grpc.ServerStream, req *pb.AppendRequest, jc pb.JournalClient) error {
+	var ctx = pb.WithDispatchRoute(stream.Context(), req.Header.Route, req.Header.ProcessId)
+
+	var client, err = jc.Append(ctx)
+	if err != nil {
+		return err
+	}
+	for {
+		if err = client.SendMsg(req); err != nil {
+			return err
+		} else if err = stream.RecvMsg(req); err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+	}
+	if resp, err := client.CloseAndRecv(); err != nil {
+		return err
+	} else {
+		return stream.SendMsg(resp)
+	}
+}
+
+// serveAppend evaluates a client's Append RPC against the local coordinated pipeline.
+func serveAppend(stream pb.Journal_AppendServer, pln *pipeline, spec *pb.JournalSpec, releaseCh chan<- *pipeline) error {
+	// We start with sole ownership of the _send_ side of the pipeline.
+	// Forward the client's content through the pipeline.
+	var appender = beginAppending(pln, spec.Fragment)
+	for appender.onRecv(stream.Recv()) {
+	}
+	addTrace(stream.Context(), "read client EOF => %s", appender)
+
+	var plnSendErr = pln.sendErr()
+	var waitFor, closeAfter = pln.barrier()
+
+	if plnSendErr == nil {
+		releaseCh <- pln // Release the send-side of |pln|.
+	} else {
+		pln.closeSend()
+		releaseCh <- nil // Allow a new pipeline to be built.
+
+		log.WithFields(log.Fields{"err": plnSendErr, "journal": spec.Name}).
+			Warn("pipeline send failed")
+	}
+
+	// There may be pipelined commits prior to this one, who have not yet read
+	// their responses. Block until they do so, such that our responses are the
+	// next to receive. Similarly, defer a close to signal to RPCs pipelined
+	// after this one, that they may in turn read their responses. When this
+	// completes, we have sole ownership of the _receive_ side of |pln|.
+	select {
+	case <-waitFor:
+	default:
+		addTrace(stream.Context(), " ... stalled in <-waitFor read barrier")
+		<-waitFor
+	}
+	defer func() { close(closeAfter) }()
+
+	// We expect an acknowledgement from each peer. If we encountered a send
+	// error, we also expect an EOF from remaining non-broken peers.
+	if pln.gatherOK(); plnSendErr != nil {
+		pln.gatherEOF()
+	}
+
+	if pln.recvErr() != nil {
+		log.WithFields(log.Fields{"err": pln.recvErr(), "journal": spec.Name}).
+			Warn("pipeline receive failed")
+	}
+
+	if appender.reqErr != nil {
+		return appender.reqErr
+	} else if plnSendErr != nil {
+		return plnSendErr
+	} else if pln.recvErr() != nil {
+		return pln.recvErr()
+	} else {
+		return stream.SendMsg(&pb.AppendResponse{
+			Header: &pln.Header,
+			Commit: appender.reqFragment,
+		})
+	}
+}
+
+// appender streams Append content through the pipeline, tracking the exact
+// Journal Fragment appended by the RPC and any client error.
+type appender struct {
+	pln  *pipeline
+	spec pb.JournalSpec_Fragment
+
+	reqCommit   bool
+	reqErr      error
+	reqFragment *pb.Fragment
+	reqSummer   hash.Hash
+}
+
+// beginAppending updates the current proposal, if needed, then initializes
+// and returns an appender.
+func beginAppending(pln *pipeline, spec pb.JournalSpec_Fragment) appender {
+	// Potentially roll the Fragment forward prior to serving the append.
+	// We expect this to always succeed and don't ask for an acknowledgement.
+	var proposal, update = updateProposal(pln.spool.Fragment.Fragment, spec)
+
+	if update {
+		pln.scatter(&pb.ReplicateRequest{
+			Proposal:    &proposal,
+			Acknowledge: false,
+		})
+	}
+
+	return appender{
+		pln:  pln,
+		spec: spec,
+
+		reqFragment: &pb.Fragment{
+			Journal:          pln.spool.Fragment.Journal,
+			Begin:            pln.spool.Fragment.End,
+			End:              pln.spool.Fragment.End,
+			CompressionCodec: pln.spool.Fragment.CompressionCodec,
+		},
+		reqSummer: sha1.New(),
+	}
+}
+
+// onRecv is called with each received content message or error
+// from the Append RPC client.
+func (a *appender) onRecv(req *pb.AppendRequest, err error) bool {
+	// Ensure |req| is a valid content chunk.
+	if err == nil {
+		if err = req.Validate(); err == nil && req.Journal != "" {
+			err = errExpectedContentChunk
+		}
+	}
+
+	if err == io.EOF && !a.reqCommit {
+		// EOF without first receiving an empty chunk is unexpected,
+		// and we treat it as a roll-back.
+		err = io.ErrUnexpectedEOF
+	} else if err == nil && a.reqCommit {
+		// *Not* reading an EOF after reading an empty chunk is also unexpected.
+		err = errExpectedEOF
+	} else if err == nil && len(req.Content) == 0 {
+		// Empty chunk indicates an EOF will follow, at which point we commit.
+		a.reqCommit = true
+		return true
+	} else if err == nil {
+		// Regular content chunk. Forward it through the pipeline.
+		a.pln.scatter(&pb.ReplicateRequest{
+			Content:      req.Content,
+			ContentDelta: a.reqFragment.ContentLength(),
+		})
+		_, _ = a.reqSummer.Write(req.Content) // Cannot error.
+		a.reqFragment.End += int64(len(req.Content))
+
+		return a.pln.sendErr() == nil
+	}
+
+	// We've reached end-of-input for this Append stream.
+	a.reqFragment.Sum = pb.SHA1SumFromDigest(a.reqSummer.Sum(nil))
+
+	var proposal = new(pb.Fragment)
+	if err == io.EOF {
+		if !a.reqCommit {
+			panic("invariant violated: reqCommit = true")
+		}
+		// Commit the Append, by scattering the next Fragment to be committed
+		// to each peer. They will inspect & validate the Fragment locally,
+		// and commit or return an error.
+		*proposal = a.pln.spool.Next()
+	} else {
+		// A client-side read error occurred. The pipeline is still in a good
+		// state, but any partial spooled content must be rolled back.
+		*proposal = a.pln.spool.Fragment.Fragment
+
+		a.reqErr = err
+		a.reqFragment = nil
+	}
+
+	a.pln.scatter(&pb.ReplicateRequest{
+		Proposal:    proposal,
+		Acknowledge: true,
+	})
+	return false
+}
+
+// String returns a debugging representation of the appender.
+func (a appender) String() string {
+	return fmt.Sprintf("appender<reqCommit: %t, reqErr: %v, reqFragment: %s>",
+		a.reqCommit, a.reqErr, a.reqFragment.String())
+}
+
+// updateProposal applies JournalSpec configuration to a replicated pipeline,
+// by proposing that the pipeline roll to a new, empty configured Fragment.
+func updateProposal(cur pb.Fragment, spec pb.JournalSpec_Fragment) (pb.Fragment, bool) {
+	// If the proposed Fragment is non-empty, but not yet at the target length,
+	// don't propose changes to it.
+	if cur.ContentLength() > 0 && cur.ContentLength() < spec.Length {
+		return cur, false
+	}
+
+	var next = cur
+	next.Begin = next.End
+	next.Sum = pb.SHA1Sum{}
+	next.CompressionCodec = spec.CompressionCodec
+
+	if len(spec.Stores) != 0 {
+		next.BackingStore = spec.Stores[0]
+	} else {
+		next.BackingStore = ""
+	}
+	return next, next != cur
+}
+
+var (
+	errExpectedEOF          = fmt.Errorf("expected EOF after empty Content chunk")
+	errExpectedContentChunk = fmt.Errorf("expected Content chunk")
+)

--- a/v2/pkg/broker/append_api_test.go
+++ b/v2/pkg/broker/append_api_test.go
@@ -1,0 +1,491 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+)
+
+type AppendSuite struct{}
+
+func (s *AppendSuite) TestSingleAppend(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 2, broker.id, peer.id)
+	broker.replicas["a/journal"].index.ReplaceRemote(fragment.CoverSet{}) // Unblock initial load.
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+
+	var stream, _ = broker.MustClient().Append(pb.WithDispatchDefault(ctx))
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+	expectPipelineSync(c, peer, res.Header)
+
+	c.Check(stream.Send(&pb.AppendRequest{Content: []byte("foo")}), gc.IsNil)
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("foo"), ContentDelta: 0})
+	c.Check(stream.Send(&pb.AppendRequest{Content: []byte("bar")}), gc.IsNil)
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("bar"), ContentDelta: 3})
+
+	// Send empty chunk and close the Append RPC. Expect replication peer receives a commit request.
+	c.Check(stream.Send(&pb.AppendRequest{}), gc.IsNil)
+	c.Check(stream.CloseSend(), gc.IsNil)
+
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              6,
+			Sum:              pb.SHA1SumOf("foobar"),
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+		Acknowledge: true,
+	})
+	peer.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK} // Acknowledge.
+
+	// Expect the client stream receives an AppendResponse.
+	resp, err := stream.CloseAndRecv()
+	c.Check(err, gc.IsNil)
+
+	c.Check(resp, gc.DeepEquals, &pb.AppendResponse{
+		Status: pb.Status_OK,
+		Header: &res.Header,
+		Commit: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              6,
+			Sum:              pb.SHA1SumOf("foobar"),
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+	})
+}
+
+func (s *AppendSuite) TestPipelinedAppends(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 2, broker.id, peer.id)
+	broker.replicas["a/journal"].index.ReplaceRemote(fragment.CoverSet{}) // Unblock initial load.
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+
+	// Build two raced Append requests.
+	ctx = pb.WithDispatchDefault(ctx)
+	var stream1, _ = broker.MustClient().Append(ctx)
+	var stream2, _ = broker.MustClient().Append(ctx)
+
+	// |stream1| is sequenced first; expect it's replicated to the peer.
+	c.Check(stream1.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+	expectPipelineSync(c, peer, res.Header)
+	c.Check(stream1.Send(&pb.AppendRequest{Content: []byte("foo")}), gc.IsNil)
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("foo"), ContentDelta: 0})
+	c.Check(stream1.Send(&pb.AppendRequest{}), gc.IsNil) // Signal commit.
+	c.Check(stream1.CloseSend(), gc.IsNil)
+
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              3,
+			Sum:              pb.SHA1SumOf("foo"),
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+		Acknowledge: true,
+	})
+
+	// |stream2| follows. Expect it's also replicated, without first performing a pipeline sync.
+	c.Check(stream2.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+	c.Check(stream2.Send(&pb.AppendRequest{Content: []byte("bar")}), gc.IsNil)
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("bar"), ContentDelta: 0})
+	c.Check(stream2.Send(&pb.AppendRequest{Content: []byte("baz")}), gc.IsNil)
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("baz"), ContentDelta: 3})
+	c.Check(stream2.Send(&pb.AppendRequest{}), gc.IsNil) // Signal commit.
+	c.Check(stream2.CloseSend(), gc.IsNil)
+
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              9,
+			Sum:              pb.SHA1SumOf("foobarbaz"),
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+		Acknowledge: true,
+	})
+
+	// Peer finally acknowledges first commit. This unblocks |stream1|'s response.
+	peer.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+	resp, err := stream1.CloseAndRecv()
+	c.Check(err, gc.IsNil)
+
+	c.Check(resp, gc.DeepEquals, &pb.AppendResponse{
+		Status: pb.Status_OK,
+		Header: &res.Header,
+		Commit: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              3,
+			Sum:              pb.SHA1SumOf("foo"),
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+	})
+
+	// Peer acknowledges second commit. |stream2|'s response is unblocked.
+	peer.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+	resp, err = stream2.CloseAndRecv()
+	c.Check(err, gc.IsNil)
+
+	c.Check(resp, gc.DeepEquals, &pb.AppendResponse{
+		Status: pb.Status_OK,
+		Header: &res.Header,
+		Commit: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            3,
+			End:              9,
+			Sum:              pb.SHA1SumOf("barbaz"),
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+	})
+}
+
+func (s *AppendSuite) TestRollbackCases(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 2, broker.id, peer.id)
+	broker.replicas["a/journal"].index.ReplaceRemote(fragment.CoverSet{}) // Unblock initial load.
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+
+	ctx = pb.WithDispatchDefault(ctx)
+
+	// Case: client explicitly rolls back by closing the stream without first sending an empty chunk.
+	var stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+	expectPipelineSync(c, peer, res.Header)
+
+	c.Check(stream.Send(&pb.AppendRequest{Content: []byte("foo")}), gc.IsNil)
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("foo"), ContentDelta: 0})
+	c.Check(stream.CloseSend(), gc.IsNil)
+
+	// Expect replication peer receives a rollback.
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+		Acknowledge: true,
+	})
+	peer.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK} // Acknowledge.
+
+	// Expect the client reads an error.
+	var _, err = stream.CloseAndRecv()
+	c.Check(err, gc.ErrorMatches, `rpc error: code = Unknown desc = unexpected EOF`)
+
+	// Case: client read error occurs.
+	var failCtx, failCtxCancel = context.WithCancel(ctx)
+
+	stream, _ = broker.MustClient().Append(failCtx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+
+	c.Check(stream.Send(&pb.AppendRequest{Content: []byte("foo")}), gc.IsNil)
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("foo"), ContentDelta: 0})
+	failCtxCancel() // Cancel the stream.
+
+	// Expect replication peer receives a rollback.
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+		Acknowledge: true,
+	})
+	peer.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK} // Acknowledge.
+
+	_, err = stream.CloseAndRecv()
+	c.Check(err, gc.ErrorMatches, `rpc error: code = Canceled desc = context canceled`)
+}
+
+func (s *AppendSuite) TestRequestErrorCases(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	ctx = pb.WithDispatchDefault(ctx)
+
+	// Case: AppendRequest which fails to validate.
+	var stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "/invalid/name"}), gc.IsNil)
+
+	var _, err = stream.CloseAndRecv()
+	c.Check(err, gc.ErrorMatches, `rpc error: code = Unknown desc = Journal: cannot begin with '/' .*`)
+
+	// Case: Journal doesn't exist.
+	stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "does/not/exist"}), gc.IsNil)
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "does/not/exist"})
+
+	resp, err := stream.CloseAndRecv()
+	c.Check(err, gc.IsNil)
+	c.Check(resp, gc.DeepEquals, &pb.AppendResponse{Status: pb.Status_JOURNAL_NOT_FOUND, Header: &res.Header})
+	c.Check(resp.Header.Route, gc.DeepEquals, res.Header.Route)
+
+	// Case: Journal with no assigned primary.
+	// Arrange Journal assignment fixture such that R=1, but the broker has Slot=1 (and is not primary).
+	newTestJournal(c, ks, "no/primary", 1, pb.ProcessSpec_ID{}, broker.id)
+	res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "no/primary"})
+
+	stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "no/primary"}), gc.IsNil)
+
+	resp, err = stream.CloseAndRecv()
+	c.Check(err, gc.IsNil)
+	c.Check(resp, gc.DeepEquals, &pb.AppendResponse{Status: pb.Status_NO_JOURNAL_PRIMARY_BROKER, Header: &res.Header})
+
+	// Case: Journal with a primary but not enough replication peers.
+	newTestJournal(c, ks, "not/enough/peers", 3, broker.id, peer.id)
+	res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "not/enough/peers"})
+
+	stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "not/enough/peers"}), gc.IsNil)
+
+	resp, err = stream.CloseAndRecv()
+	c.Check(err, gc.IsNil)
+	c.Check(resp, gc.DeepEquals, &pb.AppendResponse{Status: pb.Status_INSUFFICIENT_JOURNAL_BROKERS, Header: &res.Header})
+}
+
+func (s *AppendSuite) TestProxyCases(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 1, peer.id)
+	var res, _ = broker.resolve(resolveArgs{
+		ctx:            ctx,
+		journal:        "a/journal",
+		mayProxy:       true,
+		requirePrimary: true,
+	})
+	ctx = pb.WithDispatchDefault(ctx)
+
+	// Case: initial request is proxied to the peer, with Header attached.
+	var stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+
+	c.Check(<-peer.AppendReqCh, gc.DeepEquals, &pb.AppendRequest{
+		Journal: "a/journal",
+		Header:  &res.Header,
+	})
+
+	// Expect client content and EOF are proxied.
+	c.Check(stream.Send(&pb.AppendRequest{Content: []byte("foobar")}), gc.IsNil)
+	c.Check(<-peer.AppendReqCh, gc.DeepEquals, &pb.AppendRequest{Content: []byte("foobar")})
+	c.Check(stream.Send(&pb.AppendRequest{}), gc.IsNil)
+	c.Check(<-peer.AppendReqCh, gc.DeepEquals, &pb.AppendRequest{})
+	c.Check(stream.CloseSend(), gc.IsNil)
+	c.Check(<-peer.AppendReqCh, gc.IsNil)
+
+	// Expect peer's response is proxied back to the client.
+	peer.AppendRespCh <- &pb.AppendResponse{Commit: &pb.Fragment{Begin: 1234, End: 5678}}
+
+	var resp, err = stream.CloseAndRecv()
+	c.Check(err, gc.IsNil)
+	c.Check(resp, gc.DeepEquals, &pb.AppendResponse{Commit: &pb.Fragment{Begin: 1234, End: 5678}})
+
+	// Case: proxied request fails due to broker failure.
+	stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+
+	c.Check(<-peer.AppendReqCh, gc.DeepEquals, &pb.AppendRequest{
+		Journal: "a/journal",
+		Header:  &res.Header,
+	})
+
+	// Expect peer error is proxied back to client.
+	peer.ErrCh <- errors.New("some kind of error")
+	_, err = stream.CloseAndRecv()
+	c.Check(<-peer.AppendReqCh, gc.IsNil) // Read client EOF.
+	c.Check(err, gc.ErrorMatches, `rpc error: code = Unknown desc = some kind of error`)
+
+	// Case: proxied request fails due to client read error.
+	var failCtx, failCtxCancel = context.WithCancel(ctx)
+
+	stream, _ = broker.MustClient().Append(failCtx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "a/journal"}), gc.IsNil)
+
+	c.Check(<-peer.AppendReqCh, gc.DeepEquals, &pb.AppendRequest{
+		Journal: "a/journal",
+		Header:  &res.Header,
+	})
+
+	failCtxCancel()
+	c.Check(<-peer.AppendReqCh, gc.IsNil) // Expect EOF, which is treated as rollback by appender.
+
+	_, err = stream.CloseAndRecv()
+	c.Check(err, gc.ErrorMatches, `rpc error: code = Canceled desc = context canceled`)
+}
+
+func (s *AppendSuite) TestAppenderCases(c *gc.C) {
+	var rm = newReplicationMock(c)
+	defer rm.cancel()
+
+	// Tweak Spool fixture to have a non-zero size & sum.
+	var spool = <-rm.spoolCh
+	spool.Fragment.End = 24
+	spool.Fragment.Sum = pb.SHA1Sum{Part1: 1234}
+	rm.spoolCh <- spool
+	var pln = rm.newPipeline(rm.header(0, 100))
+
+	var spec = pb.JournalSpec_Fragment{
+		Length:           16, // Fix such that current Spool is over target length.
+		CompressionCodec: pb.CompressionCodec_SNAPPY,
+		Stores:           []pb.FragmentStore{"s3://a-bucket/path"},
+	}
+	var appender = beginAppending(pln, spec)
+
+	// Expect an updating proposal is scattered.
+	c.Check(<-rm.brokerA.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Begin:            24,
+			End:              24,
+			Journal:          "a/journal",
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+			BackingStore:     "s3://a-bucket/path",
+		},
+		Acknowledge: false,
+	})
+	<-rm.brokerC.ReplReqCh
+
+	// Chunk one. Expect it's forwarded to peers.
+	c.Check(appender.onRecv(&pb.AppendRequest{Content: []byte("foo")}, nil), gc.Equals, true)
+	var req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{
+		Content:      []byte("foo"),
+		ContentDelta: 0,
+	})
+	// Chunk two.
+	c.Check(appender.onRecv(&pb.AppendRequest{Content: []byte("bar")}, nil), gc.Equals, true)
+	req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{
+		Content:      []byte("bar"),
+		ContentDelta: 3,
+	})
+	// Empty chunk signals we wish to commit.
+	c.Check(appender.onRecv(&pb.AppendRequest{}, nil), gc.Equals, true)
+	c.Check(appender.reqCommit, gc.Equals, true)
+
+	// Client EOF. Expect a commit proposal is scattered to peers.
+	c.Check(appender.onRecv(nil, io.EOF), gc.Equals, false)
+
+	var expect = &pb.Fragment{
+		Journal:          "a/journal",
+		Begin:            24,
+		End:              30,
+		Sum:              pb.SHA1Sum{Part1: 0x8843d7f92416211d, Part2: 0xe9ebb963ff4ce281, Part3: 0x25932878},
+		CompressionCodec: pb.CompressionCodec_SNAPPY,
+		BackingStore:     "s3://a-bucket/path",
+	}
+	req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{Proposal: expect, Acknowledge: true})
+
+	c.Check(appender.reqFragment, gc.DeepEquals, &pb.Fragment{
+		Journal:          "a/journal",
+		Begin:            24,
+		End:              30,
+		Sum:              pb.SHA1Sum{Part1: 0x8843d7f92416211d, Part2: 0xe9ebb963ff4ce281, Part3: 0x25932878},
+		CompressionCodec: pb.CompressionCodec_SNAPPY,
+	})
+	c.Check(appender.reqErr, gc.IsNil)
+
+	// Case: Expect a non-validating AppendRequest is treated as a client error, and triggers rollback.
+	// Also, first expect an updating proposal is not required and is not sent this time.
+	appender = beginAppending(pln, spec)
+
+	// Valid first chunk.
+	c.Check(appender.onRecv(&pb.AppendRequest{Content: []byte("baz")}, nil), gc.Equals, true)
+	req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{Content: []byte("baz")})
+
+	// Send invalid AppendRequest.
+	c.Check(appender.onRecv(&pb.AppendRequest{Journal: "/invalid"}, nil), gc.Equals, false)
+	c.Check(appender.reqFragment, gc.IsNil)
+	c.Check(appender.reqErr, gc.ErrorMatches, `Journal: cannot begin with '/' \(/invalid\)`)
+
+	// Expect a rollback is scattered to peers.
+	req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{Proposal: expect, Acknowledge: true})
+
+	// Case: Expect an EOF without first sending an empty chunk is unexpected, and triggers a rollback.
+	// Also check an updated proposal is still not sent, despite the spec codec
+	// differing, because the spool is non-empty and not over the Fragment Length.
+	spec.CompressionCodec = pb.CompressionCodec_GZIP
+	appender = beginAppending(pln, spec)
+
+	// Send unexpected EOF.
+	c.Check(appender.onRecv(nil, io.EOF), gc.Equals, false)
+	c.Check(appender.reqErr, gc.Equals, io.ErrUnexpectedEOF)
+
+	req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{Proposal: expect, Acknowledge: true})
+
+	// Case: Expect another read error triggers a rollback.
+	appender = beginAppending(pln, spec)
+	c.Check(appender.onRecv(nil, errors.New("some error")), gc.Equals, false)
+	c.Check(appender.reqErr, gc.DeepEquals, errors.New("some error"))
+
+	req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{Proposal: expect, Acknowledge: true})
+
+	// Case: Expect *not* reading an EOF after a commit chunk triggers an error and rollback.
+	appender = beginAppending(pln, spec)
+
+	c.Check(appender.onRecv(&pb.AppendRequest{}, nil), gc.Equals, true)
+	c.Check(appender.onRecv(&pb.AppendRequest{Content: []byte("foo")}, nil), gc.Equals, false)
+	c.Check(appender.reqErr, gc.DeepEquals, errExpectedEOF)
+
+	req, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	c.Check(req, gc.DeepEquals, &pb.ReplicateRequest{Proposal: expect, Acknowledge: true})
+}
+
+func expectPipelineSync(c *gc.C, peer *testBroker, hdr pb.Header) {
+	// Expect an initial request, with header, synchronizing the replication pipeline.
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Journal: "a/journal",
+		Header:  boxHeaderProcessID(hdr, peer.id),
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: true,
+	})
+	peer.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK} // Acknowledge.
+
+	// Expect a non-ack'd command to roll the Spool to the SNAPPY codec (configured in the fixture).
+	c.Check(<-peer.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			CompressionCodec: pb.CompressionCodec_SNAPPY,
+		},
+	})
+}
+
+var _ = gc.Suite(&AppendSuite{})

--- a/v2/pkg/broker/doc.go
+++ b/v2/pkg/broker/doc.go
@@ -1,0 +1,7 @@
+// Package broker implements the broker runtime and protocol.JournalServer APIs
+// (Read, Append, Replicate, List, Apply). Its `pipeline` type manages the
+// coordination of write transactions, and `resolver` the mapping of journal
+// names to Routes of responsible brokers. `replica` is a top-level collection
+// of runtime state and maintenance tasks associated with the processing of a
+// journal. gRPC proxy support is also implemented by this package.
+package broker

--- a/v2/pkg/broker/e2e_test.go
+++ b/v2/pkg/broker/e2e_test.go
@@ -1,0 +1,58 @@
+package broker
+
+import (
+	"context"
+
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+)
+
+// TODO(johnny): Add additional E2E testing scenarios (Issue #66).
+
+type E2ESuite struct{}
+
+func (s *E2ESuite) TestReplicatedAppendAndRead(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	newTestJournal(c, ks, "journal/one", 2, broker.id, peer.id)
+	newTestJournal(c, ks, "journal/two", 2, peer.id, broker.id)
+
+	// "Complete" initial remote load.
+	broker.replicas["journal/one"].index.ReplaceRemote(fragment.CoverSet{})
+	peer.replicas["journal/two"].index.ReplaceRemote(fragment.CoverSet{})
+
+	ctx = pb.WithDispatchDefault(ctx)
+	var rOne, _ = peer.MustClient().Read(ctx, &pb.ReadRequest{Journal: "journal/one", Block: true})
+	var rTwo, _ = broker.MustClient().Read(ctx, &pb.ReadRequest{Journal: "journal/two", Block: true})
+
+	// First Append is served by |broker|, with its Read served by |peer|.
+	var stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "journal/one"}), gc.IsNil)
+	c.Check(stream.Send(&pb.AppendRequest{Content: []byte("hello")}), gc.IsNil)
+	c.Check(stream.Send(&pb.AppendRequest{}), gc.IsNil)
+	_, _ = stream.CloseAndRecv()
+
+	// Second Append is served by |peer| (through |broker|), with its Read served by |broker|.
+	stream, _ = broker.MustClient().Append(ctx)
+	c.Check(stream.Send(&pb.AppendRequest{Journal: "journal/two"}), gc.IsNil)
+	c.Check(stream.Send(&pb.AppendRequest{Content: []byte("world!")}), gc.IsNil)
+	c.Check(stream.Send(&pb.AppendRequest{}), gc.IsNil)
+	_, _ = stream.CloseAndRecv()
+
+	// Read Fragment metadata, then content from each Read stream.
+	_, err := rOne.Recv()
+	c.Check(err, gc.IsNil)
+	_, err = rTwo.Recv()
+	c.Check(err, gc.IsNil)
+
+	expectReadResponse(c, rOne, &pb.ReadResponse{Content: []byte("hello")})
+	expectReadResponse(c, rTwo, &pb.ReadResponse{Content: []byte("world!")})
+}
+
+var _ = gc.Suite(&E2ESuite{})

--- a/v2/pkg/broker/integration/integration_test.go
+++ b/v2/pkg/broker/integration/integration_test.go
@@ -1,0 +1,201 @@
+// Package integration is a test-only package of broker integration tests.
+package integration
+
+import (
+	"bufio"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LiveRamp/gazette/v2/pkg/allocator"
+	"github.com/LiveRamp/gazette/v2/pkg/broker"
+	"github.com/LiveRamp/gazette/v2/pkg/broker/teststub"
+	"github.com/LiveRamp/gazette/v2/pkg/client"
+	"github.com/LiveRamp/gazette/v2/pkg/etcdtest"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	gc "github.com/go-check/check"
+)
+
+// TODO(johnny): Add additional integration testing scenarios (Issue #69).
+
+type IntegrationSuite struct{}
+
+func (s *IntegrationSuite) TestBasicReadAndWrite(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+	defer etcdtest.Cleanup()
+
+	var etcd, session = etcdSession(c)
+
+	var ks = broker.NewKeySpace("/gazette/cluster")
+	c.Check(ks.Load(ctx, etcd, 0), gc.IsNil)
+	go ks.Watch(ctx, etcd)
+
+	var brokerA = newTestServer(pb.BrokerSpec{
+		ProcessSpec: pb.ProcessSpec{
+			Id: pb.ProcessSpec_ID{Zone: "A", Suffix: "broker-one"},
+		},
+		JournalLimit: 5,
+	})
+	var brokerB = newTestServer(pb.BrokerSpec{
+		ProcessSpec: pb.ProcessSpec{
+			Id: pb.ProcessSpec_ID{Zone: "B", Suffix: "broker-two"},
+		},
+		JournalLimit: 5,
+	})
+
+	brokerA.start(c, ctx, ks, session, etcd)
+	brokerB.start(c, ctx, ks, session, etcd)
+
+	var journal = createTestJournal(c, ks, etcd)
+
+	// TODO(johnny): This is super ugly. Can we use the AllocateArgs hook to
+	// drive test stages upon reaching idle-ness?
+	time.Sleep(time.Millisecond * 500)
+
+	ctx = pb.WithDispatchDefault(ctx)
+
+	var r = client.NewReader(ctx,
+		pb.NewRoutedJournalClient(brokerA.srv.MustClient(), pb.NoopDispatchRouter{}),
+		pb.ReadRequest{
+			Journal: journal,
+			Block:   true,
+		})
+	var a = client.NewAppender(ctx,
+		pb.NewRoutedJournalClient(brokerB.srv.MustClient(), pb.NoopDispatchRouter{}),
+		pb.AppendRequest{
+			Journal: journal,
+		})
+
+	go func() {
+		var _, err = a.Write([]byte("hello, world!\nextra"))
+		c.Check(err, gc.IsNil)
+		c.Check(a.Close(), gc.IsNil)
+	}()
+
+	var br = bufio.NewReader(r)
+	str, err := br.ReadString('\n')
+	c.Check(err, gc.IsNil)
+	c.Check(str, gc.Equals, "hello, world!\n")
+
+	// Lower journal replication to one. This allows |brokerA| to exit gracefully.
+	setJournalReplication(c, ks, etcd, journal, 1)
+	brokerA.gracefulStop(c, ctx)
+
+	// Delete the journal. |brokerB| can now exit.
+	_, err = etcd.Delete(context.Background(),
+		allocator.ItemKey(ks, journal.String()))
+	c.Check(err, gc.IsNil)
+
+	brokerB.gracefulStop(c, ctx)
+}
+
+type testBroker struct {
+	spec         pb.BrokerSpec
+	key          string
+	state        *allocator.State
+	srv          *teststub.Server
+	svc          broker.Service
+	announcement *allocator.Announcement
+	stopped      chan struct{}
+}
+
+func newTestServer(spec pb.BrokerSpec) *testBroker {
+	return &testBroker{spec: spec}
+}
+
+func (s *testBroker) start(c *gc.C, ctx context.Context, ks *keyspace.KeySpace, session *concurrency.Session, etcd *clientv3.Client) {
+
+	s.key = allocator.MemberKey(ks, s.spec.Id.Zone, s.spec.Id.Suffix)
+	s.state = allocator.NewObservedState(ks, s.key)
+	s.srv = teststub.NewServer(c, ctx, &s.svc)
+	s.svc = *broker.NewService(s.state, s.srv.MustClient(), etcd)
+	s.spec.Endpoint = s.srv.Endpoint()
+	s.announcement = allocator.Announce(etcd, s.key, s.spec.MarshalString(), session.Lease())
+	s.stopped = make(chan struct{})
+
+	go func() {
+
+		// Wait until our member key is reflected in KeySpace, before starting Allocate.
+		ks.Mu.RLock()
+		c.Check(ks.WaitForRevision(ctx, s.announcement.Revision), gc.IsNil)
+		ks.Mu.RUnlock()
+
+		c.Check(allocator.Allocate(allocator.AllocateArgs{
+			Context: ctx,
+			Etcd:    etcd,
+			State:   s.state,
+		}), gc.IsNil)
+		close(s.stopped)
+	}()
+}
+
+func (s *testBroker) gracefulStop(c *gc.C, ctx context.Context) {
+	s.spec.JournalLimit = 0
+	c.Check(s.announcement.Update(s.spec.MarshalString()), gc.IsNil)
+	<-s.stopped
+}
+
+func createTestJournal(c *gc.C, ks *keyspace.KeySpace, etcd *clientv3.Client) pb.Journal {
+	var spec = pb.JournalSpec{
+		Name:        "foo/bar",
+		Replication: 2,
+		Fragment: pb.JournalSpec_Fragment{
+			Length:           1 << 16,
+			CompressionCodec: pb.CompressionCodec_GZIP,
+			RefreshInterval:  time.Second,
+		},
+		LabelSet: pb.LabelSet{
+			Labels: []pb.Label{
+				{Name: "label-key", Value: "label-value"},
+				{Name: "topic", Value: "foo"},
+			},
+		},
+	}
+	c.Check(spec.Validate(), gc.IsNil)
+
+	var resp, err = etcd.Put(context.Background(),
+		allocator.ItemKey(ks, spec.Name.String()),
+		spec.MarshalString(),
+	)
+	c.Check(err, gc.IsNil)
+
+	ks.Mu.RLock()
+	ks.WaitForRevision(context.Background(), resp.Header.Revision)
+	ks.Mu.RUnlock()
+
+	return spec.Name
+}
+
+func setJournalReplication(c *gc.C, ks *keyspace.KeySpace, etcd *clientv3.Client, journal pb.Journal, r int32) {
+	var spec pb.JournalSpec
+
+	if item, ok := allocator.LookupItem(ks, journal.String()); ok {
+		spec = *item.ItemValue.(*pb.JournalSpec)
+	} else {
+		c.Fatalf("journal not found: %s", journal)
+	}
+
+	spec.Replication = r
+	var _, err = etcd.Put(context.Background(),
+		allocator.ItemKey(ks, spec.Name.String()),
+		spec.MarshalString(),
+	)
+	c.Check(err, gc.IsNil)
+}
+
+func etcdSession(c *gc.C) (*clientv3.Client, *concurrency.Session) {
+	var etcd = etcdtest.TestClient()
+
+	var session, err = concurrency.NewSession(etcd)
+	c.Assert(err, gc.IsNil)
+
+	return etcd, session
+}
+
+func Test(t *testing.T) { gc.TestingT(t) }
+
+var _ = gc.Suite(&IntegrationSuite{})

--- a/v2/pkg/broker/key_space.go
+++ b/v2/pkg/broker/key_space.go
@@ -1,0 +1,65 @@
+package broker
+
+import (
+	"github.com/LiveRamp/gazette/v2/pkg/allocator"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+)
+
+// NewKeySpace returns a KeySpace suitable for use with an Allocator.
+// It decodes allocator Items as JournalSpec messages, Members as BrokerSpecs,
+// and Assignments as Routes.
+func NewKeySpace(prefix string) *keyspace.KeySpace {
+	return allocator.NewAllocatorKeySpace(prefix, decoder{})
+}
+
+// decoder is an instance of allocator.Decoder. It strictly enforces that
+// JournalSpec.Name and BrokerSpec.ID match those derived from the Spec's
+// Etcd key. Conceptually, the Etcd key is source-of-truth regarding entity
+// naming, but it's helpful to carry these identifiers within the specs
+// themselves, making them a stand-alone representation and allowing for
+// content-addressing of a spec into its appropriate Etcd key. This decoder
+// behavior provides an assertion that these identifiers never diverge.
+type decoder struct{}
+
+func (d decoder) DecodeItem(id string, raw *mvccpb.KeyValue) (allocator.ItemValue, error) {
+	var s = new(pb.JournalSpec)
+
+	if err := s.Unmarshal(raw.Value); err != nil {
+		return nil, err
+	} else if err = s.Validate(); err != nil {
+		return nil, err
+	} else if s.Name.String() != id {
+		return nil, pb.NewValidationError("JournalSpec Name doesn't match Item ID (%+v vs %+v)", s.Name, id)
+	}
+	return s, nil
+}
+
+func (d decoder) DecodeMember(zone, suffix string, raw *mvccpb.KeyValue) (allocator.MemberValue, error) {
+	var s = new(pb.BrokerSpec)
+
+	if err := s.Unmarshal(raw.Value); err != nil {
+		return nil, err
+	} else if err = s.Validate(); err != nil {
+		return nil, err
+	} else if s.Id.Zone != zone {
+		return nil, pb.NewValidationError("BrokerSpec Zone doesn't match Member Zone (%+v vs %+v)", s.Id.Zone, zone)
+	} else if s.Id.Suffix != suffix {
+		return nil, pb.NewValidationError("BrokerSpec Suffix doesn't match Member Suffix (%+v vs %+v)", s.Id.Suffix, suffix)
+	}
+	return s, nil
+}
+
+func (d decoder) DecodeAssignment(itemID, memberZone, memberSuffix string, slot int, raw *mvccpb.KeyValue) (allocator.AssignmentValue, error) {
+	var s = new(pb.Route)
+
+	if len(raw.Value) == 0 {
+		s.Init(nil)
+	} else if err := s.Unmarshal(raw.Value); err != nil {
+		return nil, err
+	} else if err = s.Validate(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/v2/pkg/broker/list_apply_api.go
+++ b/v2/pkg/broker/list_apply_api.go
@@ -1,0 +1,99 @@
+package broker
+
+import (
+	"context"
+	"strings"
+
+	"github.com/LiveRamp/gazette/v2/pkg/allocator"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	"github.com/coreos/etcd/clientv3"
+)
+
+// List dispatches the JournalServer.List API.
+func (srv *Service) List(ctx context.Context, req *pb.ListRequest) (*pb.ListResponse, error) {
+	var s = srv.resolver.state
+
+	var resp = &pb.ListResponse{
+		Status: pb.Status_OK,
+		Header: pb.NewUnroutedHeader(s),
+	}
+	if err := req.Validate(); err != nil {
+		return resp, err
+	}
+
+	// TODO(johnny): Implement support for PageLimit & PageToken.
+
+	var metaLabels, allLabels pb.LabelSet
+
+	defer s.KS.Mu.RUnlock()
+	s.KS.Mu.RLock()
+
+	var it = allocator.LeftJoin{
+		LenL: len(s.Items),
+		LenR: len(s.Assignments),
+		Compare: func(l, r int) int {
+			var lID = s.Items[l].Decoded.(allocator.Item).ID
+			var rID = s.Assignments[r].Decoded.(allocator.Assignment).ItemID
+			return strings.Compare(lID, rID)
+		},
+	}
+	for cur, ok := it.Next(); ok; cur, ok = it.Next() {
+		var journal = pb.ListResponse_Journal{
+			Spec: *s.Items[cur.Left].Decoded.(allocator.Item).ItemValue.(*pb.JournalSpec)}
+
+		metaLabels = pb.ExtractJournalSpecMetaLabels(&journal.Spec, metaLabels)
+		allLabels = pb.UnionLabelSets(metaLabels, journal.Spec.LabelSet, allLabels)
+
+		if !req.Selector.Matches(allLabels) {
+			continue
+		}
+		journal.ModRevision = s.Items[cur.Left].Raw.ModRevision
+		journal.Route.Init(s.Assignments[cur.RightBegin:cur.RightEnd])
+		journal.Route.AttachEndpoints(s.KS)
+
+		resp.Journals = append(resp.Journals, journal)
+	}
+	return resp, nil
+}
+
+// Apply dispatches the JournalServer.Apply API.
+func (srv *Service) Apply(ctx context.Context, req *pb.ApplyRequest) (*pb.ApplyResponse, error) {
+	var s = srv.resolver.state
+
+	var resp = &pb.ApplyResponse{
+		Status: pb.Status_OK,
+		Header: pb.NewUnroutedHeader(s),
+	}
+	if err := req.Validate(); err != nil {
+		return resp, err
+	}
+
+	var cmp []clientv3.Cmp
+	var ops []clientv3.Op
+
+	for _, change := range req.Changes {
+		var key string
+
+		if change.Upsert != nil {
+			key = allocator.ItemKey(s.KS, change.Upsert.Name.String())
+			ops = append(ops, clientv3.OpPut(key, change.Upsert.MarshalString()))
+		} else {
+			key = allocator.ItemKey(s.KS, change.Delete.String())
+			ops = append(ops, clientv3.OpDelete(key))
+		}
+		cmp = append(cmp, clientv3.Compare(clientv3.ModRevision(key), "=", change.ExpectModRevision))
+	}
+
+	if txnResp, err := srv.etcd.Do(ctx, clientv3.OpTxn(cmp, ops, nil)); err != nil {
+		return resp, err
+	} else if !txnResp.Txn().Succeeded {
+		resp.Status = pb.Status_ETCD_TRANSACTION_FAILED
+	} else {
+		// Delay responding until we have read our own Etcd write.
+		s.KS.Mu.RLock()
+		s.KS.WaitForRevision(ctx, txnResp.Txn().Header.Revision)
+		s.KS.Mu.RUnlock()
+	}
+
+	return resp, nil
+}

--- a/v2/pkg/broker/list_apply_api_test.go
+++ b/v2/pkg/broker/list_apply_api_test.go
@@ -1,0 +1,6 @@
+package broker
+
+// TODO(johnny): Switch broker tests to use the etcdtest module...
+// Rather than faking etcd (these tests were written prior to etcdtest existing).
+// Then, this test implementation becomes straightforward, paralleling that of
+// the consumer package.

--- a/v2/pkg/broker/pipeline.go
+++ b/v2/pkg/broker/pipeline.go
@@ -1,0 +1,292 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	log "github.com/sirupsen/logrus"
+)
+
+// pipeline is an in-flight write replication pipeline of a journal.
+type pipeline struct {
+	pb.Header                                  // Header of the pipeline.
+	spool         fragment.Spool               // Local, primary replication Spool.
+	returnCh      chan<- fragment.Spool        // |spool| return channel.
+	streams       []pb.Journal_ReplicateClient // Established streams to each replication peer.
+	sendErrs      []error                      // First error on send from each peer.
+	readBarrierCh chan struct{}                // Coordinates hand-off of receive-side of the pipeline.
+	recvResp      []pb.ReplicateResponse       // Most recent response gathered from each peer.
+	recvErrs      []error                      // First error on receive from each peer.
+
+	// readThroughRev, if set, indicates that a pipeline cannot be established
+	// until we have read through (and our Route reflects) this etcd revision.
+	readThroughRev int64
+}
+
+// newPipeline returns a new pipeline.
+func newPipeline(ctx context.Context, hdr pb.Header, spool fragment.Spool, returnCh chan<- fragment.Spool, jc pb.JournalClient) *pipeline {
+	if hdr.Route.Primary == -1 {
+		panic("dial requires Route with Primary != -1")
+	}
+	var R = len(hdr.Route.Members)
+
+	var pln = &pipeline{
+		Header:        hdr,
+		spool:         spool,
+		returnCh:      returnCh,
+		streams:       make([]pb.Journal_ReplicateClient, R),
+		sendErrs:      make([]error, R),
+		readBarrierCh: make(chan struct{}),
+		recvResp:      make([]pb.ReplicateResponse, R),
+		recvErrs:      make([]error, R),
+	}
+	close(pln.readBarrierCh)
+
+	for i := range pln.Route.Members {
+		if i == int(pln.Route.Primary) {
+			continue
+		}
+		pln.streams[i], pln.sendErrs[i] = jc.Replicate(
+			pb.WithDispatchRoute(ctx, pln.Route, pln.Route.Members[i]))
+	}
+	return pln
+}
+
+// synchronize all pipeline peers by scattering proposals and gathering peer
+// responses. On disagreement, synchronize will iteratively update the proposal
+// if it's possible to do so and reach agreement. If peers disagree on Etcd
+// revision, synchronize will close the pipeline and set |readThroughRev|.
+func (pln *pipeline) synchronize() error {
+	var proposal = pln.spool.Fragment.Fragment
+
+	for {
+		pln.scatter(&pb.ReplicateRequest{
+			Header:      &pln.Header,
+			Journal:     pln.spool.Journal,
+			Proposal:    &proposal,
+			Acknowledge: true,
+		})
+		var rollToOffset, readThroughRev = pln.gatherSync(proposal)
+
+		var err = pln.recvErr()
+		if err == nil {
+			err = pln.sendErr()
+		}
+
+		if err != nil {
+			pln.shutdown(true)
+			return err
+		}
+
+		if rollToOffset != 0 {
+			// Update our |proposal| to roll forward to the new offset. Loop to try
+			// again. This time all peers should agree on the new Fragment.
+			proposal.Begin = rollToOffset
+			proposal.End = rollToOffset
+			proposal.Sum = pb.SHA1Sum{}
+			continue
+		}
+
+		if readThroughRev != 0 {
+			// Peer has a non-equivalent Route at a later etcd revision. Close the
+			// pipeline, and set its |readThroughRev| as an indication to other RPCs
+			// of the revision which must first be read through before attempting
+			// another pipeline.
+			pln.shutdown(false)
+			pln.readThroughRev = readThroughRev
+		}
+		return nil
+	}
+}
+
+// scatter asynchronously applies the ReplicateRequest to all replicas.
+func (pln *pipeline) scatter(r *pb.ReplicateRequest) {
+	for i, s := range pln.streams {
+		if s != nil && pln.sendErrs[i] == nil {
+			if r.Header != nil {
+				// Copy and update to peer ProcessID.
+				r.Header = boxHeaderProcessID(*r.Header, pln.Route.Members[i])
+			}
+			pln.sendErrs[i] = s.Send(r)
+		}
+	}
+	if i := pln.Route.Primary; pln.sendErrs[i] == nil {
+		var resp pb.ReplicateResponse
+
+		// Map an error into a |sendErr|.
+		// Status !OK is returned only on proposal mismatch, which cannot happen
+		// here as all proposals are derived from the Spool itself.
+		if resp, pln.sendErrs[i] = pln.spool.Apply(r, true); resp.Status != pb.Status_OK {
+			panic(resp.String())
+		}
+	}
+}
+
+// closeSend closes the send-side of all replica connections.
+func (pln *pipeline) closeSend() {
+	// Apply a Spool commit which rolls back any partial content.
+	pln.spool.MustApply(&pb.ReplicateRequest{
+		Proposal: &pln.spool.Fragment.Fragment,
+	})
+	pln.returnCh <- pln.spool // Release ownership of Spool.
+
+	for i, s := range pln.streams {
+		if s != nil && pln.sendErrs[i] == nil {
+			pln.sendErrs[i] = s.CloseSend()
+		}
+	}
+}
+
+// sendErr returns the first encountered send-side error.
+func (pln *pipeline) sendErr() error {
+	for i, err := range pln.sendErrs {
+		if err != nil {
+			return fmt.Errorf("send to %s: %s", &pln.Route.Members[i], err)
+		}
+	}
+	return nil
+}
+
+// barrier installs a new barrier in the pipeline. Clients should:
+//   * Invoke barrier after issuing all sent writes, and release the
+//     pipeline for other clients.
+//   * Block until |waitFor| is selectable.
+//   * Read expected responses from the pipeline.
+//   * Close |closeAfter|.
+// By following this convention a pipeline can safely be passed among multiple
+// clients, each performing writes followed by reads, while allowing for those
+// writes and reads to happen concurrently.
+func (pln *pipeline) barrier() (waitFor <-chan struct{}, closeAfter chan<- struct{}) {
+	waitFor, pln.readBarrierCh = pln.readBarrierCh, make(chan struct{})
+	closeAfter = pln.readBarrierCh
+	return
+}
+
+// gather synchronously receives a ReplicateResponse from all replicas.
+func (pln *pipeline) gather() {
+	for i, s := range pln.streams {
+		if s != nil && pln.recvErrs[i] == nil {
+			pln.recvErrs[i] = s.RecvMsg(&pln.recvResp[i])
+		}
+	}
+}
+
+// gatherOK calls gather, and treats any non-OK response status as an error.
+func (pln *pipeline) gatherOK() {
+	pln.gather()
+
+	for i, s := range pln.streams {
+		if s == nil || pln.recvErrs[i] != nil {
+			// Pass.
+		} else if pln.recvResp[i].Status != pb.Status_OK {
+			pln.recvErrs[i] = fmt.Errorf("unexpected !OK response: %s", &pln.recvResp[i])
+		}
+	}
+}
+
+// gatherSync calls gather, extracts and returns a peer-advertised future offset
+// or etcd revision to read through relative to |proposal|, and treats any other
+// non-OK response status as an error.
+func (pln *pipeline) gatherSync(proposal pb.Fragment) (rollToOffset, readThroughRev int64) {
+	pln.gather()
+
+	for i, s := range pln.streams {
+		if s == nil || pln.recvErrs[i] != nil {
+			continue
+		}
+
+		switch resp := pln.recvResp[i]; resp.Status {
+		case pb.Status_OK:
+			// Pass.
+		case pb.Status_WRONG_ROUTE:
+			if !resp.Header.Route.Equivalent(&pln.Route) && resp.Header.Etcd.Revision > pln.Etcd.Revision {
+				// Peer has a non-equivalent Route at a later etcd revision.
+				if resp.Header.Etcd.Revision > readThroughRev {
+					readThroughRev = resp.Header.Etcd.Revision
+				}
+			} else {
+				pln.recvErrs[i] = fmt.Errorf("unexpected WRONG_ROUTE: %s", resp.Header)
+			}
+
+		case pb.Status_FRAGMENT_MISMATCH:
+			if resp.Fragment.Begin != proposal.Begin &&
+				resp.Fragment.End >= proposal.End {
+				// Peer has a Fragment at matched or larger End offset, and with a
+				// differing Begin offset.
+				if resp.Fragment.End > rollToOffset {
+					rollToOffset = resp.Fragment.End
+				}
+			} else {
+				pln.recvErrs[i] = fmt.Errorf("unexpected FRAGMENT_MISMATCH: %s", resp.Fragment)
+			}
+
+		default:
+			pln.recvErrs[i] = fmt.Errorf("unexpected Status: %s", &resp)
+		}
+	}
+	return
+}
+
+// gatherEOF synchronously gathers expected EOFs from all replicas.
+// An unexpected received message is treated as an error.
+func (pln *pipeline) gatherEOF() {
+	for i, s := range pln.streams {
+		if s == nil {
+			continue
+		}
+		var msg, err = s.Recv()
+
+		if err == io.EOF {
+			// Pass.
+		} else if pln.recvErrs[i] == nil && err != nil {
+			pln.recvErrs[i] = err
+		} else if pln.recvErrs[i] == nil && err == nil {
+			pln.recvErrs[i] = fmt.Errorf("unexpected response: %s", msg.String())
+		}
+	}
+}
+
+// recvErr returns the first encountered receive-side error.
+func (pln *pipeline) recvErr() error {
+	for i, err := range pln.recvErrs {
+		if err != nil {
+			return fmt.Errorf("recv from %s: %s", &pln.Route.Members[i], err)
+		}
+	}
+	return nil
+}
+
+// shutdown performs a graceful, blocking shutdown of the pipeline.
+func (pln *pipeline) shutdown(expectErr bool) {
+	var waitFor, closeAfter = pln.barrier()
+
+	if pln.closeSend(); !expectErr && pln.sendErr() != nil {
+		log.WithField("err", pln.sendErr()).Warn("tearing down pipeline: failed to closeSend")
+	}
+	<-waitFor
+
+	if pln.gatherEOF(); !expectErr && pln.recvErr() != nil {
+		log.WithField("err", pln.recvErr()).Warn("tearing down pipeline: failed to gatherEOF")
+	}
+	close(closeAfter)
+}
+
+// String is used to provide debugging output of a pipeline in a request trace.
+func (pln *pipeline) String() string {
+	if pln == nil {
+		return "<nil>"
+	} else if pln.readThroughRev != 0 {
+		return fmt.Sprintf("readThroughRev<%d>", pln.readThroughRev)
+	}
+	return fmt.Sprintf("pipeline<header: %s, spool: %s>", &pln.Header, pln.spool.String())
+}
+
+func boxHeaderProcessID(hdr pb.Header, id pb.ProcessSpec_ID) *pb.Header {
+	var out = new(pb.Header)
+	*out = hdr
+	out.ProcessId = id
+	return out
+}

--- a/v2/pkg/broker/pipeline_test.go
+++ b/v2/pkg/broker/pipeline_test.go
@@ -1,0 +1,394 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/LiveRamp/gazette/v2/pkg/broker/teststub"
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+)
+
+type PipelineSuite struct{}
+
+func (s *PipelineSuite) TestBasicLifeCycle(c *gc.C) {
+	var rm = newReplicationMock(c)
+	defer rm.cancel()
+
+	var pln = rm.newPipeline(rm.header(0, 100))
+
+	var req = &pb.ReplicateRequest{Content: []byte("foobar")}
+	pln.scatter(req)
+
+	c.Check(pln.sendErr(), gc.IsNil)
+	c.Check(<-rm.brokerA.ReplReqCh, gc.DeepEquals, req)
+	c.Check(<-rm.brokerC.ReplReqCh, gc.DeepEquals, req)
+
+	var proposal = pln.spool.Next()
+	req = &pb.ReplicateRequest{Proposal: &proposal}
+	pln.scatter(req)
+
+	c.Check(pln.sendErr(), gc.IsNil)
+	c.Check(<-rm.brokerA.ReplReqCh, gc.DeepEquals, req)
+	c.Check(<-rm.brokerC.ReplReqCh, gc.DeepEquals, req)
+
+	var waitFor1, closeAfter1 = pln.barrier()
+
+	// Second client issues a write and close.
+	pln.scatter(&pb.ReplicateRequest{Content: []byte("bazbing")})
+	_, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	pln.closeSend()
+
+	c.Check(pln.sendErr(), gc.IsNil)
+	c.Check(<-rm.brokerA.ReplReqCh, gc.IsNil) // Expect EOF.
+	c.Check(<-rm.brokerC.ReplReqCh, gc.IsNil) // Expect EOF.
+
+	var waitFor2, closeAfter2 = pln.barrier()
+
+	// First client reads its response.
+	<-waitFor1
+
+	rm.brokerA.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+	rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+
+	pln.gatherOK()
+	c.Check(pln.recvErr(), gc.IsNil)
+	c.Check(pln.recvResp, gc.DeepEquals, []pb.ReplicateResponse{{}, {}, {}})
+
+	close(closeAfter1)
+
+	// Second client reads its response.
+	<-waitFor2
+
+	rm.brokerA.ErrCh <- nil // Send EOF.
+	rm.brokerC.ErrCh <- nil // Send EOF.
+
+	pln.gatherEOF()
+	c.Check(pln.recvErr(), gc.IsNil)
+
+	close(closeAfter2)
+}
+
+func (s *PipelineSuite) TestPeerErrorCases(c *gc.C) {
+	var rm = newReplicationMock(c)
+	defer rm.cancel()
+
+	var pln = rm.newPipeline(rm.header(0, 100))
+
+	var req = &pb.ReplicateRequest{Content: []byte("foo")}
+	pln.scatter(req)
+
+	c.Check(pln.sendErr(), gc.IsNil)
+	c.Check(<-rm.brokerA.ReplReqCh, gc.DeepEquals, req)
+	c.Check(<-rm.brokerC.ReplReqCh, gc.DeepEquals, req)
+
+	// Have peer A return an error. Peer B returns a non-OK response status (where OK is expected).
+	rm.brokerA.ErrCh <- errors.New("error!")
+	rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_FRAGMENT_MISMATCH}
+
+	// Expect pipeline retains the first recv error for each peer.
+	pln.gatherOK()
+	c.Check(pln.recvErrs[0], gc.ErrorMatches, `rpc error: code = Unknown desc = error!`)
+	c.Check(pln.recvErrs[1], gc.IsNil)
+	c.Check(pln.recvErrs[2], gc.ErrorMatches, `unexpected !OK response: status:FRAGMENT_MISMATCH `)
+
+	// Expect recvErr decorates the first error with peer metadata.
+	c.Check(pln.recvErr(), gc.ErrorMatches, `recv from zone:"A" suffix:"1" : rpc error: .*`)
+
+	// Scatter a ReplicateRequest to each peer.
+	req = &pb.ReplicateRequest{Content: []byte("bar"), ContentDelta: 99999} // Invalid ContentDelta.
+	pln.scatter(req)
+
+	// Expect pipeline retains the first send error for each peer, including the local Spool.
+	// |rm.brokerA|'s stream is already closed, and the attempted send will error with EOF
+	// (non-standard, but just how gRPC does it). The request is immediately applied to the
+	// local Spool during scatter(), and we expect its error is tracked on |sendErrs|. No
+	// error occurs on send to|rm.brokerC| (though its |recvErr| is still set).
+	c.Check(pln.sendErrs[0], gc.ErrorMatches, `EOF`)
+	c.Check(pln.sendErrs[1], gc.ErrorMatches, `invalid ContentDelta \(99999; expected 3\)`)
+	c.Check(pln.sendErrs[2], gc.IsNil)
+
+	c.Check(<-rm.brokerC.ReplReqCh, gc.DeepEquals, req)
+
+	// Expect sendErr decorates the first error with peer metadata.
+	c.Check(pln.sendErr(), gc.ErrorMatches, `send to zone:"A" suffix:"1" : EOF`)
+
+	pln.closeSend()
+
+	// Finish shutdown by having brokerC receive and send EOF.
+	c.Check(<-rm.brokerC.ReplReqCh, gc.IsNil)
+	rm.brokerC.ErrCh <- nil
+	pln.gatherEOF()
+
+	// Restart a new pipeline. Immediately send an EOF, and test handling of
+	// an unexpected received message prior to peer EOF.
+	pln = rm.newPipeline(rm.header(0, 100))
+	pln.closeSend()
+
+	c.Check(<-rm.brokerA.ReplReqCh, gc.IsNil) // Read EOF.
+	c.Check(<-rm.brokerC.ReplReqCh, gc.IsNil) // Read EOF.
+
+	rm.brokerA.ErrCh <- nil                                                       // Send EOF.
+	rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_WRONG_ROUTE} // Unexpected response.
+	rm.brokerC.ErrCh <- nil                                                       // Now, send EOF.
+
+	pln.gatherEOF()
+	c.Check(pln.recvErrs[0], gc.IsNil)
+	c.Check(pln.recvErrs[1], gc.IsNil)
+	c.Check(pln.recvErrs[2], gc.ErrorMatches, `unexpected response: status:WRONG_ROUTE `)
+}
+
+func (s *PipelineSuite) TestGatherSyncCases(c *gc.C) {
+	var rm = newReplicationMock(c)
+	defer rm.cancel()
+
+	var pln = rm.newPipeline(rm.header(0, 100))
+
+	var req = &pb.ReplicateRequest{
+		Header:  rm.header(1, 100),
+		Journal: "a/journal",
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            123,
+			End:              123,
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: true,
+	}
+	pln.scatter(req)
+
+	// Expect each peer sees |req| with its ID in the Header.
+	req.Header = rm.header(0, 100)
+	c.Check(<-rm.brokerA.ReplReqCh, gc.DeepEquals, req)
+	req.Header = rm.header(2, 100)
+	c.Check(<-rm.brokerC.ReplReqCh, gc.DeepEquals, req)
+
+	// Craft a peer response Header at a later revision, with a different Route.
+	var wrongRouteHdr = rm.header(0, 4567)
+	wrongRouteHdr.Route.Members[0].Suffix = "other"
+
+	rm.brokerA.ReplRespCh <- &pb.ReplicateResponse{
+		Status: pb.Status_WRONG_ROUTE,
+		Header: wrongRouteHdr,
+	}
+	rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{
+		Status:   pb.Status_FRAGMENT_MISMATCH,
+		Fragment: &pb.Fragment{Begin: 567, End: 890},
+	}
+
+	// Expect the new Fragment offset and etcd revision to read through are returned.
+	var rollToOffset, readRev = pln.gatherSync(*req.Proposal)
+	c.Check(rollToOffset, gc.Equals, int64(890))
+	c.Check(readRev, gc.Equals, int64(4567))
+	c.Check(pln.recvErr(), gc.IsNil)
+	c.Check(pln.sendErr(), gc.IsNil)
+
+	// Again. This time peers return success.
+	req.Proposal = &pb.Fragment{
+		Journal:          "a/journal",
+		Begin:            890,
+		End:              890,
+		CompressionCodec: pb.CompressionCodec_NONE,
+	}
+	pln.scatter(req)
+
+	_, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+	rm.brokerA.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+	rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+
+	rollToOffset, readRev = pln.gatherSync(*req.Proposal)
+	c.Check(rollToOffset, gc.Equals, int64(0))
+	c.Check(readRev, gc.Equals, int64(0))
+	c.Check(pln.recvErr(), gc.IsNil)
+	c.Check(pln.sendErr(), gc.IsNil)
+
+	// Again. This time, peers return !OK status with invalid responses.
+	pln.scatter(req)
+
+	_, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+
+	rm.brokerA.ReplRespCh <- &pb.ReplicateResponse{
+		Status: pb.Status_WRONG_ROUTE,
+		Header: rm.header(0, 99), // Revision not greater than |pln|'s.
+	}
+	rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{
+		Status:   pb.Status_FRAGMENT_MISMATCH,
+		Fragment: &pb.Fragment{Begin: 567, End: 889}, // End offset < proposal.
+	}
+
+	rollToOffset, readRev = pln.gatherSync(*req.Proposal)
+	c.Check(rollToOffset, gc.Equals, int64(0))
+	c.Check(readRev, gc.Equals, int64(0))
+	c.Check(pln.sendErr(), gc.IsNil)
+	c.Check(pln.recvErr(), gc.NotNil)
+
+	c.Check(pln.recvErrs[0], gc.ErrorMatches, `unexpected WRONG_ROUTE: process_id:.*`)
+	c.Check(pln.recvErrs[1], gc.IsNil)
+	c.Check(pln.recvErrs[2], gc.ErrorMatches, `unexpected FRAGMENT_MISMATCH: begin:567 end:889 .*`)
+}
+
+func (s *PipelineSuite) TestPipelineSync(c *gc.C) {
+	var rm = newReplicationMock(c)
+	defer rm.cancel()
+
+	// Tweak Spool to have a different End & Sum.
+	var spool = <-rm.spoolCh
+	spool.Fragment.End, spool.Fragment.Sum = 123, pb.SHA1Sum{Part1: 999}
+	rm.spoolCh <- spool
+
+	var pln = rm.newPipeline(rm.header(0, 100))
+
+	go func() {
+		// Read sync request.
+		c.Check(<-rm.brokerA.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+			Journal: "a/journal",
+			Header:  rm.header(0, 100),
+			Proposal: &pb.Fragment{
+				Journal:          "a/journal",
+				Begin:            0,
+				End:              123,
+				Sum:              pb.SHA1Sum{Part1: 999},
+				CompressionCodec: pb.CompressionCodec_NONE,
+			},
+			Acknowledge: true,
+		})
+		_ = <-rm.brokerC.ReplReqCh
+
+		// Peers disagree on Fragment End.
+		rm.brokerA.ReplRespCh <- &pb.ReplicateResponse{
+			Status:   pb.Status_FRAGMENT_MISMATCH,
+			Fragment: &pb.Fragment{Begin: 567, End: 892},
+		}
+		rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{
+			Status:   pb.Status_FRAGMENT_MISMATCH,
+			Fragment: &pb.Fragment{Begin: 567, End: 890},
+		}
+
+		// Next iteration. Expect proposal is updated to reflect largest offset.
+		c.Check(<-rm.brokerA.ReplReqCh, gc.DeepEquals, &pb.ReplicateRequest{
+			Journal: "a/journal",
+			Header:  rm.header(0, 100),
+			Proposal: &pb.Fragment{
+				Journal:          "a/journal",
+				Begin:            892,
+				End:              892,
+				CompressionCodec: pb.CompressionCodec_NONE,
+			},
+			Acknowledge: true,
+		})
+		_ = <-rm.brokerC.ReplReqCh
+
+		// Peers agree.
+		rm.brokerA.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+		rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+
+		// Next round.
+		_, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+
+		// Peer C response with a larger Etcd revision.
+		var wrongRouteHdr = rm.header(0, 4567)
+		wrongRouteHdr.Route.Members[0].Suffix = "other"
+
+		rm.brokerA.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+		rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{
+			Status: pb.Status_WRONG_ROUTE,
+			Header: wrongRouteHdr,
+		}
+
+		// Expect start() sends EOF.
+		c.Check(<-rm.brokerA.ReplReqCh, gc.IsNil)
+		c.Check(<-rm.brokerC.ReplReqCh, gc.IsNil)
+		rm.brokerA.ErrCh <- nil
+		rm.brokerC.ErrCh <- nil
+
+		// Next round sends an error.
+		_, _ = <-rm.brokerA.ReplReqCh, <-rm.brokerC.ReplReqCh
+		rm.brokerA.ErrCh <- errors.New("an error")
+		rm.brokerC.ReplRespCh <- &pb.ReplicateResponse{Status: pb.Status_OK}
+
+		// Expect EOF.
+		c.Check(<-rm.brokerA.ReplReqCh, gc.IsNil)
+		c.Check(<-rm.brokerC.ReplReqCh, gc.IsNil)
+		rm.brokerC.ErrCh <- nil // |brokerA| has already closed.
+	}()
+
+	c.Check(pln.synchronize(), gc.IsNil)
+	c.Check(pln.readThroughRev, gc.Equals, int64(0))
+
+	// Next round. This time, the pipeline is closed and readThroughRev is set.
+	c.Check(pln.synchronize(), gc.IsNil)
+	c.Check(pln.readThroughRev, gc.Equals, int64(4567))
+
+	// Next round with new pipeline. Peer returns an error, and it's passed through.
+	pln = rm.newPipeline(rm.header(0, 100))
+	c.Check(pln.synchronize(), gc.ErrorMatches, `recv from zone:"A" suffix:"1" : rpc error: .*`)
+}
+
+type replicationMock struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	brokerA, brokerC *teststub.Broker
+
+	spoolCh chan fragment.Spool
+
+	commits   []fragment.Fragment
+	completes []fragment.Spool
+}
+
+func newReplicationMock(c *gc.C) *replicationMock {
+	var ctx, cancel = context.WithCancel(context.Background())
+	var brokerA, brokerC = teststub.NewBroker(c, ctx), teststub.NewBroker(c, ctx)
+
+	var m = &replicationMock{
+		ctx:     ctx,
+		cancel:  cancel,
+		brokerA: brokerA,
+		brokerC: brokerC,
+		spoolCh: make(chan fragment.Spool, 1),
+	}
+	m.spoolCh <- fragment.NewSpool("a/journal", m)
+
+	return m
+}
+
+func (m *replicationMock) header(id int, rev int64) *pb.Header {
+	var hdr = &pb.Header{
+		Route: pb.Route{
+			Primary: 1,
+			Members: []pb.ProcessSpec_ID{
+				{Zone: "A", Suffix: "1"},
+				{Zone: "B", Suffix: "2"},
+				{Zone: "C", Suffix: "3"},
+			},
+			Endpoints: []pb.Endpoint{
+				m.brokerA.Endpoint(),
+				pb.Endpoint("http://[100::]"),
+				m.brokerC.Endpoint(),
+			},
+		},
+		Etcd: pb.Header_Etcd{
+			ClusterId: 12,
+			MemberId:  34,
+			Revision:  rev,
+			RaftTerm:  78,
+		},
+	}
+	hdr.ProcessId = hdr.Route.Members[id]
+	return hdr
+}
+
+func (m *replicationMock) newPipeline(hdr *pb.Header) *pipeline {
+	return newPipeline(m.ctx, *hdr, <-m.spoolCh, m.spoolCh, m.brokerA.MustClient())
+}
+
+func (m *replicationMock) SpoolCommit(f fragment.Fragment) { m.commits = append(m.commits, f) }
+func (m *replicationMock) SpoolComplete(s fragment.Spool, _ bool) {
+	m.completes = append(m.completes, s)
+}
+
+var _ = gc.Suite(&PipelineSuite{})
+
+func Test(t *testing.T) { gc.TestingT(t) }

--- a/v2/pkg/broker/read_api.go
+++ b/v2/pkg/broker/read_api.go
@@ -1,0 +1,143 @@
+package broker
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+
+	"github.com/LiveRamp/gazette/v2/pkg/client"
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// Read dispatches the JournalServer.Read API.
+func (svc *Service) Read(req *pb.ReadRequest, stream pb.Journal_ReadServer) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	var res, err = svc.resolver.resolve(resolveArgs{
+		ctx:                   stream.Context(),
+		journal:               req.Journal,
+		mayProxy:              !req.DoNotProxy,
+		requirePrimary:        false,
+		requireFullAssignment: false,
+		proxyHeader:           req.Header,
+	})
+
+	if err != nil {
+		return err
+	} else if res.status != pb.Status_OK {
+		return stream.Send(&pb.ReadResponse{
+			Status: res.status,
+			Header: &res.Header,
+		})
+	} else if res.replica == nil {
+		req.Header = &res.Header
+		return proxyRead(stream, req, svc.jc)
+	}
+
+	if err = serveRead(stream, req, &res.Header, res.replica.index); err == context.Canceled {
+		err = nil // Gracefully terminate RPC.
+	} else if err != nil {
+		log.WithFields(log.Fields{"err": err, "req": req}).Warn("failed to serve Read")
+	}
+	return err
+}
+
+// proxyRead forwards a ReadRequest to a resolved peer broker.
+func proxyRead(stream grpc.ServerStream, req *pb.ReadRequest, jc pb.JournalClient) error {
+	var ctx = pb.WithDispatchRoute(stream.Context(), req.Header.Route, req.Header.ProcessId)
+
+	var client, err = jc.Read(ctx, req)
+	if err != nil {
+		return err
+	} else if err = client.CloseSend(); err != nil {
+		return err
+	}
+
+	var resp = new(pb.ReadResponse)
+
+	for {
+		if err = client.RecvMsg(resp); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		} else if err = stream.SendMsg(resp); err != nil {
+			return err
+		}
+	}
+}
+
+// serveRead evaluates a client's Read RPC against the local replica index.
+func serveRead(stream grpc.ServerStream, req *pb.ReadRequest, hdr *pb.Header, index *fragment.Index) error {
+	var buffer = make([]byte, chunkSize)
+	var reader io.ReadCloser
+
+	for i := 0; true; i++ {
+		var resp, file, err = index.Query(stream.Context(), req)
+		if err != nil {
+			return err
+		}
+
+		// Send the Header with the first response message (only).
+		if i == 0 {
+			resp.Header = hdr
+		}
+		if err = stream.SendMsg(resp); err != nil {
+			return err
+		}
+
+		// Return after sending Metadata if the Fragment query failed,
+		// or we were only asked to send metadata, or the Fragment is
+		// remote and we're instructed to not proxy.
+		if resp.Status != pb.Status_OK || req.MetadataOnly || file == nil && req.DoNotProxy {
+			return nil
+		}
+		// Note Query may have resolved or updated req.Offset. For the remainder of
+		// this iteration, we update |req.Offset| to reference the next byte to read.
+		req.Offset = resp.Offset
+
+		if file != nil {
+			reader = ioutil.NopCloser(io.NewSectionReader(
+				file, req.Offset-resp.Fragment.Begin, resp.Fragment.End-req.Offset))
+		} else {
+			if reader, err = fragment.Open(stream.Context(), *resp.Fragment); err != nil {
+				return err
+			} else if reader, err = client.NewFragmentReader(reader, *resp.Fragment, req.Offset); err != nil {
+				return err
+			}
+		}
+
+		// Loop over chunks read from |reader|, sending each to the client.
+		var n int
+		var readErr error
+
+		for readErr == nil {
+			if n, readErr = reader.Read(buffer); n == 0 {
+				continue
+			}
+
+			if err = stream.SendMsg(&pb.ReadResponse{
+				Offset:  req.Offset,
+				Content: buffer[:n],
+			}); err != nil {
+				return err
+			}
+			req.Offset += int64(n)
+		}
+
+		if readErr != io.EOF {
+			return readErr
+		} else if err = reader.Close(); err != nil {
+			return err
+		}
+
+		// Loop to query and read the next Fragment.
+	}
+	return nil
+}
+
+var chunkSize = 1 << 17 // 128K.

--- a/v2/pkg/broker/read_api_test.go
+++ b/v2/pkg/broker/read_api_test.go
@@ -1,0 +1,259 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+)
+
+type ReadSuite struct{}
+
+// TODO(johnny): Test case covering remote fragment reads (not yet implemented; issue #67).
+
+func (s *ReadSuite) TestStreaming(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	// Make |chunkSize| small so we can test for chunking effects.
+	defer func(cs int) { chunkSize = cs }(chunkSize)
+	chunkSize = 5
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 2, broker.id)
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+	var spool, err = acquireSpool(ctx, res.replica, false)
+	c.Check(err, gc.IsNil)
+
+	stream, err := broker.MustClient().Read(pb.WithDispatchDefault(ctx),
+		&pb.ReadRequest{
+			Journal:      "a/journal",
+			Offset:       0,
+			Block:        true,
+			DoNotProxy:   true,
+			MetadataOnly: false,
+		})
+	c.Assert(err, gc.IsNil)
+	c.Check(stream.CloseSend(), gc.IsNil)
+
+	spool.MustApply(&pb.ReplicateRequest{Content: []byte("foobarbaz")})
+	spool.MustApply(&pb.ReplicateRequest{Proposal: boxFragment(spool.Next())})
+
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:    pb.Status_OK,
+		Header:    &res.Header,
+		Offset:    0,
+		WriteHead: 9,
+		Fragment: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              9,
+			Sum:              pb.SHA1SumOf("foobarbaz"),
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+	})
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:  pb.Status_OK,
+		Offset:  0,
+		Content: []byte("fooba"),
+	})
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:  pb.Status_OK,
+		Offset:  5,
+		Content: []byte("rbaz"),
+	})
+
+	// Commit more content. Expect the committed Fragment metadata is sent,
+	// along with new commit content.
+	spool.MustApply(&pb.ReplicateRequest{Content: []byte("bing")})
+	spool.MustApply(&pb.ReplicateRequest{Proposal: boxFragment(spool.Next())})
+
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:    pb.Status_OK,
+		Offset:    9,
+		WriteHead: 13,
+		Fragment: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              13,
+			Sum:              pb.SHA1SumOf("foobarbazbing"),
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+	})
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:  pb.Status_OK,
+		Offset:  9,
+		Content: []byte("bing"),
+	})
+
+	cancel()
+	_, err = stream.Recv()
+	c.Check(err, gc.ErrorMatches, `rpc error: code = Canceled .*`)
+}
+
+func (s *ReadSuite) TestMetadataAndNonBlocking(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 2, broker.id)
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+	var spool, err = acquireSpool(ctx, res.replica, false)
+	c.Check(err, gc.IsNil)
+
+	spool.MustApply(&pb.ReplicateRequest{Content: []byte("feedbeef")})
+	spool.MustApply(&pb.ReplicateRequest{Proposal: boxFragment(spool.Next())})
+
+	ctx = pb.WithDispatchDefault(ctx)
+	stream, err := broker.MustClient().Read(ctx, &pb.ReadRequest{
+		Journal:      "a/journal",
+		Offset:       3,
+		Block:        false,
+		MetadataOnly: false,
+	})
+	c.Assert(err, gc.IsNil)
+	c.Check(stream.CloseSend(), gc.IsNil)
+
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:    pb.Status_OK,
+		Header:    &res.Header,
+		Offset:    3,
+		WriteHead: 8,
+		Fragment: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              8,
+			Sum:              pb.SHA1SumOf("feedbeef"),
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+	})
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:  pb.Status_OK,
+		Offset:  3,
+		Content: []byte("dbeef"),
+	})
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:    pb.Status_OFFSET_NOT_YET_AVAILABLE,
+		Offset:    8,
+		WriteHead: 8,
+	})
+
+	_, err = stream.Recv()
+	c.Check(err, gc.Equals, io.EOF)
+
+	// Now, issue a blocking metadata-only request.
+	stream, err = broker.MustClient().Read(ctx, &pb.ReadRequest{
+		Journal:      "a/journal",
+		Offset:       8,
+		Block:        true,
+		MetadataOnly: true,
+	})
+	c.Assert(err, gc.IsNil)
+	c.Check(stream.CloseSend(), gc.IsNil)
+
+	// Commit more content, unblocking our metadata request.
+	spool.MustApply(&pb.ReplicateRequest{Content: []byte("bing")})
+	spool.MustApply(&pb.ReplicateRequest{Proposal: boxFragment(spool.Next())})
+
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status:    pb.Status_OK,
+		Header:    &res.Header,
+		Offset:    8,
+		WriteHead: 12,
+		Fragment: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              12,
+			Sum:              pb.SHA1SumOf("feedbeefbing"),
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+	})
+
+	// Expect no data is sent, and the stream is closed.
+	_, err = stream.Recv()
+	c.Check(err, gc.Equals, io.EOF)
+}
+
+func (s *ReadSuite) TestProxyCases(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 1, peer.id)
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal", mayProxy: true})
+
+	ctx = pb.WithDispatchDefault(ctx)
+
+	// Case: successfully proxies from peer.
+	var req = &pb.ReadRequest{
+		Journal:      "a/journal",
+		Offset:       0,
+		Block:        true,
+		DoNotProxy:   false,
+		MetadataOnly: false,
+	}
+	var stream, _ = broker.MustClient().Read(ctx, req)
+
+	// Expect initial request is proxied to the peer, with attached Header, followed by client EOF.
+	req.Header = &res.Header
+	c.Check(<-peer.ReadReqCh, gc.DeepEquals, req)
+
+	peer.ReadRespCh <- &pb.ReadResponse{Offset: 1234}
+	peer.ReadRespCh <- &pb.ReadResponse{Offset: 5678}
+	peer.ErrCh <- nil
+
+	expectReadResponse(c, stream, &pb.ReadResponse{Offset: 1234})
+	expectReadResponse(c, stream, &pb.ReadResponse{Offset: 5678})
+
+	var _, err = stream.Recv()
+	c.Check(err, gc.Equals, io.EOF)
+
+	// Case: proxy is not allowed.
+	req = &pb.ReadRequest{
+		Journal:    "a/journal",
+		Offset:     0,
+		DoNotProxy: true,
+	}
+	stream, _ = broker.MustClient().Read(ctx, req)
+
+	expectReadResponse(c, stream, &pb.ReadResponse{
+		Status: pb.Status_NOT_JOURNAL_BROKER,
+		Header: boxHeaderProcessID(res.Header, broker.id),
+	})
+
+	_, err = stream.Recv()
+	c.Check(err, gc.Equals, io.EOF)
+
+	// Case: remote broker returns an error.
+	req = &pb.ReadRequest{
+		Journal: "a/journal",
+		Offset:  0,
+	}
+	stream, _ = broker.MustClient().Read(ctx, req)
+
+	// Peer reads request, and returns an error.
+	<-peer.ReadReqCh
+	peer.ErrCh <- errors.New("some kind of error")
+
+	_, err = stream.Recv()
+	c.Check(err, gc.ErrorMatches, `rpc error: code = Unknown desc = some kind of error`)
+}
+
+func boxFragment(f pb.Fragment) *pb.Fragment { return &f }
+
+func expectReadResponse(c *gc.C, stream pb.Journal_ReadClient, expect *pb.ReadResponse) {
+	var resp, err = stream.Recv()
+	c.Check(err, gc.IsNil)
+	c.Check(resp, gc.DeepEquals, expect)
+}
+
+var _ = gc.Suite(&ReadSuite{})

--- a/v2/pkg/broker/replica.go
+++ b/v2/pkg/broker/replica.go
@@ -1,0 +1,331 @@
+package broker
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/LiveRamp/gazette/v2/pkg/allocator"
+	"github.com/LiveRamp/gazette/v2/pkg/client"
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	"github.com/coreos/etcd/clientv3"
+	log "github.com/sirupsen/logrus"
+)
+
+// replica is a runtime instance of a journal which is assigned to this broker.
+type replica struct {
+	journal pb.Journal
+	// Context tied to processing lifetime of this replica by this broker.
+	// Cancelled when this broker is no longer responsible for the replica.
+	ctx    context.Context
+	cancel context.CancelFunc
+	// Index of all known Fragments of the replica.
+	index *fragment.Index
+	// spoolCh synchronizes access to the single Spool of the replica.
+	spoolCh chan fragment.Spool
+	// pipelineCh synchronizes access to the single pipeline of the replica.
+	pipelineCh chan *pipeline
+	// signalMaintenanceCh allows the resolver to notify the replica's
+	// maintenanceLoop of lifecycle events. Notably:
+	//  * resolver signals on KeySpace updates when the replica is primary for
+	//    the journal, and current assignments in Etcd are inconsistent.
+	//  * resolver closes when the replica is no longer routed to this broker,
+	//    and should be gracefully terminated.
+	signalMaintenanceCh chan struct{}
+}
+
+func newReplica(journal pb.Journal) *replica {
+	var ctx, cancel = context.WithCancel(context.Background())
+
+	var r = &replica{
+		journal:             journal,
+		ctx:                 ctx,
+		cancel:              cancel,
+		index:               fragment.NewIndex(ctx),
+		spoolCh:             make(chan fragment.Spool, 1),
+		pipelineCh:          make(chan *pipeline, 1),
+		signalMaintenanceCh: make(chan struct{}, 1),
+	}
+
+	r.spoolCh <- fragment.NewSpool(journal, struct {
+		*fragment.Index
+		*fragment.Persister
+	}{r.index, sharedPersister})
+
+	r.pipelineCh <- nil
+
+	return r
+}
+
+// acquireSpool performs a blocking acquisition of the replica's single Spool.
+func acquireSpool(ctx context.Context, r *replica, waitForRemoteLoad bool) (spool fragment.Spool, err error) {
+	if waitForRemoteLoad {
+		if err = r.index.WaitForFirstRemoteRefresh(ctx); err != nil {
+			return
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		err = ctx.Err() // |ctx| cancelled.
+		return
+	case <-r.ctx.Done():
+		err = r.ctx.Err() // replica cancelled.
+		return
+	case spool = <-r.spoolCh:
+		// Pass.
+	}
+
+	if eo := r.index.EndOffset(); eo > spool.Fragment.End {
+		// If the Fragment index knows of an offset great than the current Spool,
+		// roll the Spool forward to the new offset.
+		var proposal = spool.Fragment.Fragment
+		proposal.Begin, proposal.End, proposal.Sum = eo, eo, pb.SHA1Sum{}
+
+		spool.MustApply(&pb.ReplicateRequest{Proposal: &proposal})
+	}
+
+	addTrace(ctx, "<-replica.spoolCh => %s", spool)
+	return
+}
+
+// acquirePipeline performs a blocking acquisition of the replica's single
+// pipeline, building a new pipeline if a ready instance doesn't already exist.
+func acquirePipeline(ctx context.Context, r *replica, hdr pb.Header, jc pb.JournalClient) (*pipeline, int64, error) {
+	var pln *pipeline
+
+	select {
+	case <-ctx.Done():
+		return nil, 0, ctx.Err() // |ctx| cancelled.
+	case <-r.ctx.Done():
+		return nil, 0, r.ctx.Err() // replica cancelled.
+	case pln = <-r.pipelineCh:
+		// Pass.
+	}
+	addTrace(ctx, "<-replica.pipelineCh => %s", pln)
+
+	// Is |pln| is a placeholder indicating the need to read through a revision, which we've since read through?
+	if pln != nil && pln.readThroughRev != 0 && pln.readThroughRev <= hdr.Etcd.Revision {
+		pln = nil
+	}
+
+	// If |pln| is a valid pipeline but is built on a non-equivalent & older Route,
+	// tear it down asynchronously and immediately begin a new one.
+	if pln != nil && pln.readThroughRev == 0 &&
+		!pln.Route.Equivalent(&hdr.Route) && pln.Etcd.Revision < hdr.Etcd.Revision {
+
+		go pln.shutdown(false)
+		pln = nil
+	}
+
+	var err error
+
+	if pln == nil {
+		addTrace(ctx, " ... must build new pipeline")
+
+		// We must construct a new pipeline.
+		var spool fragment.Spool
+		spool, err = acquireSpool(ctx, r, true)
+
+		if err == nil {
+			pln = newPipeline(r.ctx, hdr, spool, r.spoolCh, jc)
+			err = pln.synchronize()
+		}
+		addTrace(ctx, "newPipeline() => %s, err: %v", pln, err)
+	}
+
+	if err != nil {
+		r.pipelineCh <- nil // Release ownership, allow next acquirer to retry.
+		return nil, 0, err
+	} else if pln.readThroughRev != 0 {
+		r.pipelineCh <- pln // Release placeholder for next acquirer to observe.
+		return nil, pln.readThroughRev, nil
+	}
+
+	return pln, 0, nil
+}
+
+// maintenanceLoop performs periodic tasks of the replica, notably:
+//  * Refreshing its remote fragment listings from configured stores.
+//  * "Pulsing" the journal to ensure its liveness, and the
+//    consistency of allocator assignment values stored in Etcd.
+func maintenanceLoop(r *replica, ks *keyspace.KeySpace, rjc pb.RoutedJournalClient, etcd clientv3.KV) {
+	// Start a timer and reset channel which trigger refreshes of remote journal
+	// fragments. The duration between each refresh can change based on current
+	// configurations, so each refresh iteration passes back a duration to wait
+	// until the next iteration, via |refreshTimerResetCh|.
+	var refreshTimer = time.NewTimer(0)
+	var refreshTimerResetCh = make(chan time.Duration, 1)
+	defer refreshTimer.Stop()
+
+	// Under normal operation, we want to pulse the journal periodically,
+	// and also on-demand when signalled. However, we want to wait until a
+	// first remote refresh completes, as all writes block until it does.
+	// Then, we may begin pulse iterations.
+	var pulseTicker = time.NewTicker(pulseInterval)
+	defer pulseTicker.Stop()
+
+	// |pulseCh| is signaled from within this loop when |pulseTicker| fires,
+	// or we're signaled. However, |maybePulseCh| is set to |pulseCh| only
+	// after |firstRemoteRefreshCh| signals. By driving pulses from |maybePulseCh|,
+	// we effectively queue an initial pulse until the first fragment refresh
+	// completes, after which the pulse may proceed immediately.
+	var pulseCh = make(chan struct{}, 1)
+	var maybePulseCh chan struct{}
+
+	var firstRemoteRefreshCh = r.index.FirstRemoteRefresh()
+
+	for {
+		select {
+		case _ = <-refreshTimer.C:
+			// Begin a background refresh of remote replica fragments. When done,
+			// signal to restart |refreshTimer| with the current refresh interval.
+			go func() {
+				refreshTimerResetCh <- refreshFragments(r, ks)
+			}()
+			continue
+
+		case d := <-refreshTimerResetCh:
+			refreshTimer.Reset(d)
+
+		case _ = <-firstRemoteRefreshCh:
+			maybePulseCh = pulseCh     // Allow pulses to proceed.
+			firstRemoteRefreshCh = nil // No longer selects.
+
+		case _, ok := <-r.signalMaintenanceCh:
+			if !ok {
+				shutDownReplica(r)
+				return
+			}
+			select {
+			case pulseCh <- struct{}{}:
+			default: // Already a queued pulse.
+			}
+
+		case _ = <-pulseTicker.C:
+			select {
+			case pulseCh <- struct{}{}:
+			default: // Already a queued pulse.
+			}
+
+		case _ = <-maybePulseCh:
+			var ctx, _ = context.WithTimeout(r.ctx, pulseInterval)
+			pulseJournal(ctx, r.journal, ks, rjc, etcd)
+		}
+	}
+}
+
+func shutDownReplica(r *replica) {
+	if pln := <-r.pipelineCh; pln != nil && pln.readThroughRev == 0 {
+		pln.shutdown(false)
+	}
+	var sp = <-r.spoolCh
+
+	// Roll the Spool forward to finalize & persist its current Fragment.
+	var proposal = sp.Fragment.Fragment
+	proposal.Begin, proposal.Sum = proposal.End, pb.SHA1Sum{}
+	sp.MustApply(&pb.ReplicateRequest{Proposal: &proposal})
+
+	// We intentionally don't return the pipeline or spool to their channels.
+	// Cancelling the replica Context will immediately fail any current or
+	// future attempts to deque either.
+	r.cancel()
+}
+
+func pulseJournal(ctx context.Context, journal pb.Journal, ks *keyspace.KeySpace, rjc pb.RoutedJournalClient, etcd clientv3.KV) {
+	var app = client.NewAppender(ctx, rjc, pb.AppendRequest{Journal: journal})
+
+	if err := app.Close(); err != nil {
+		log.WithFields(log.Fields{
+			"journal": journal,
+			"err":     err,
+			"resp":    app.Response,
+		}).Warn("pulse append failed")
+		return
+	}
+
+	ks.Mu.RLock()
+	var assignments = ks.Prefixed(allocator.ItemAssignmentsPrefix(ks, journal.String())).Copy()
+	ks.Mu.RUnlock()
+
+	// Check that the response Route is equivalent to current |assignments|. It
+	// may not be, if this pulse happened to race a concurrent allocator update.
+	var rt pb.Route
+	rt.Init(assignments)
+
+	if !rt.Equivalent(&app.Response.Header.Route) {
+		log.WithFields(log.Fields{
+			"journal": journal,
+			"rt":      rt.String(),
+			"resp":    app.Response,
+		}).Warn("pulse Route differs")
+		return
+	}
+
+	// Construct an Etcd transaction which asserts |assignments| are unchanged
+	// and updates non-equivalent values to the |rt| Route serialization,
+	// bringing them to a state of advertised consistency.
+	var cmp []clientv3.Cmp
+	var ops []clientv3.Op
+	var value = rt.MarshalString()
+
+	for _, kv := range assignments {
+		var key = string(kv.Raw.Key)
+
+		if !rt.Equivalent(kv.Decoded.(allocator.Assignment).AssignmentValue.(*pb.Route)) {
+			ops = append(ops, clientv3.OpPut(key, value, clientv3.WithIgnoreLease()))
+		}
+		cmp = append(cmp, clientv3.Compare(clientv3.ModRevision(key), "=", kv.Raw.ModRevision))
+	}
+
+	if len(ops) == 0 {
+		// Trivial success. No |assignment| values need to be updated.
+	} else if resp, err := etcd.Txn(ctx).If(cmp...).Then(ops...).Commit(); err != nil {
+		log.WithField("err", err).Warn("etcd txn failed")
+	} else {
+
+		// Note that transactions may not succeed under regular operation.
+		// For example, a primary may race a journal pulse under an updated
+		// route against an allocator's compaction of assignment slots,
+		// and lose. We expect to converge quickly via another pulse attempt.
+
+		// Wait for KeySpace to reflect our txn revision.
+		ks.Mu.RLock()
+		ks.WaitForRevision(ctx, resp.Header.Revision)
+		ks.Mu.RUnlock()
+	}
+}
+
+func refreshFragments(r *replica, ks *keyspace.KeySpace) time.Duration {
+	ks.Mu.RLock()
+	var item, ok = allocator.LookupItem(ks, r.journal.String())
+	ks.Mu.RUnlock()
+
+	if !ok {
+		return math.MaxInt64
+	}
+
+	var spec = item.ItemValue.(*pb.JournalSpec)
+	var set, err = fragment.WalkAllStores(r.ctx, spec.Name, spec.Fragment.Stores)
+
+	if err == nil {
+		r.index.ReplaceRemote(set)
+	} else {
+		log.WithFields(log.Fields{
+			"name":     spec.Name,
+			"err":      err,
+			"interval": spec.Fragment.RefreshInterval,
+		}).Warn("failed to refresh remote fragments (will retry)")
+	}
+	return spec.Fragment.RefreshInterval
+}
+
+var (
+	pulseInterval   = time.Minute
+	sharedPersister *fragment.Persister
+)
+
+// SetSharedPersister sets the Persister instance used by the `broker` package.
+func SetSharedPersister(p *fragment.Persister) { sharedPersister = p }

--- a/v2/pkg/broker/replica_test.go
+++ b/v2/pkg/broker/replica_test.go
@@ -1,0 +1,149 @@
+package broker
+
+import (
+	"context"
+	"time"
+
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+)
+
+type ReplicaSuite struct{}
+
+// TODO(johnny): Additional unit-test coverage needed here (issue #68).
+
+func (s *ReplicaSuite) TestSpoolAcquisition(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	var r = newReplica("foobar")
+
+	var spool, err = acquireSpool(ctx, r, false)
+	c.Check(err, gc.IsNil)
+	c.Check(spool.Fragment.Fragment, gc.DeepEquals, pb.Fragment{
+		Journal:          "foobar",
+		CompressionCodec: pb.CompressionCodec_NONE,
+	})
+
+	// A next attempt to acquire the Spool will block until the current instance is returned.
+	go func(s fragment.Spool) {
+		s.Fragment.Begin = 8
+		s.Fragment.End = 8
+		s.Fragment.Sum = pb.SHA1Sum{Part1: 01234}
+		r.spoolCh <- s
+	}(spool)
+
+	spool, err = acquireSpool(ctx, r, false)
+	c.Check(err, gc.IsNil)
+
+	c.Check(spool.Fragment.Fragment, gc.DeepEquals, pb.Fragment{
+		Journal:          "foobar",
+		Begin:            8,
+		End:              8,
+		Sum:              pb.SHA1Sum{Part1: 01234},
+		CompressionCodec: pb.CompressionCodec_NONE,
+	})
+	r.spoolCh <- spool
+
+	// acquireSpool optionally waits on the fragment.Index to load. Further,
+	// expect the Spool will roll forward if the Index is aware of a greater offset.
+
+	go func() {
+		var set, _ = fragment.CoverSet{}.Add(fragment.Fragment{
+			Fragment: pb.Fragment{
+				Journal:          "foobar",
+				Begin:            10,
+				End:              20,
+				CompressionCodec: pb.CompressionCodec_NONE,
+			},
+		})
+		r.index.ReplaceRemote(set)
+	}()
+
+	spool, err = acquireSpool(ctx, r, true)
+	c.Check(err, gc.IsNil)
+
+	c.Check(spool.Fragment.Fragment, gc.DeepEquals, pb.Fragment{
+		Journal:          "foobar",
+		Begin:            20,
+		End:              20,
+		CompressionCodec: pb.CompressionCodec_NONE,
+	})
+
+	// Note |spool| is not returned. Cancel |ctx| in the background.
+	go cancel()
+
+	_, err = acquireSpool(ctx, r, false)
+	c.Check(err, gc.Equals, context.Canceled)
+}
+
+func (s *ReplicaSuite) TestPipelineAcquisition(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+	var jc = broker.MustClient()
+
+	newTestJournal(c, ks, "a/journal", 2, broker.id, peer.id)
+	broker.replicas["a/journal"].index.ReplaceRemote(fragment.CoverSet{}) // Unblock initial load.
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+
+	// Create an "outdated" header having an older revision and a non-equivalent Route.
+	var hdr = res.Header
+	hdr.Etcd.Revision -= 1
+	hdr.Route.Members = []pb.ProcessSpec_ID{{Zone: "different", Suffix: "broker"}, {Zone: "peer", Suffix: "broker"}}
+
+	// Expect no pipeline is returned, and the Revision to read through is.
+	var pln, rev, err = acquirePipeline(ctx, res.replica, hdr, jc)
+	c.Check(pln, gc.IsNil)
+	c.Check(rev, gc.Equals, ks.Header.Revision)
+	c.Check(err, gc.IsNil)
+
+	// Expect |readThroughRev| is set on the pipeline.
+	pln = <-res.replica.pipelineCh
+	c.Check(pln.readThroughRev, gc.Equals, ks.Header.Revision)
+	res.replica.pipelineCh <- pln
+
+	// Repeated invocations return |readThroughRev| again.
+	_, rev, _ = acquirePipeline(ctx, res.replica, hdr, jc)
+	c.Check(rev, gc.Equals, ks.Header.Revision)
+
+	// Try again with a "current" header. It succeeds.
+	pln, rev, err = acquirePipeline(ctx, res.replica, res.Header, jc)
+	c.Check(pln, gc.NotNil)
+	c.Check(rev, gc.Equals, int64(0))
+	c.Check(err, gc.IsNil)
+
+	var didRun bool
+	go func() {
+		time.Sleep(time.Millisecond)
+		didRun = true
+		res.replica.pipelineCh <- pln
+	}()
+
+	// Next invocation blocks until the pipeline is returned by the last caller.
+	pln, rev, err = acquirePipeline(ctx, res.replica, res.Header, jc)
+	c.Check(pln, gc.NotNil)
+	c.Check(didRun, gc.Equals, true)
+	res.replica.pipelineCh <- pln
+
+	// Introduce a new peer, update the Journal Route, and the resolution.
+	var peer2 = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker2"})
+	newTestJournal(c, ks, "a/journal", 2, broker.id, peer.id, peer2.id)
+	res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+
+	// Expect the pipeline was re-built, using the updated Route.
+	pln, rev, err = acquirePipeline(ctx, res.replica, res.Header, jc)
+	c.Check(pln, gc.NotNil)
+	c.Check(err, gc.IsNil)
+	c.Check(pln.Header.Route.Members, gc.DeepEquals, []pb.ProcessSpec_ID{broker.id, peer.id, peer2.id})
+
+	// Don't return |pln|. Attempts to acquire it block indefinitely, until the context is cancelled.
+	go cancel()
+
+	_, _, err = acquirePipeline(ctx, res.replica, res.Header, jc)
+	c.Check(err, gc.Equals, context.Canceled)
+}
+
+var _ = gc.Suite(&ReplicaSuite{})

--- a/v2/pkg/broker/replicate_api.go
+++ b/v2/pkg/broker/replicate_api.go
@@ -1,0 +1,85 @@
+package broker
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/LiveRamp/gazette/v2/pkg/fragment"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	log "github.com/sirupsen/logrus"
+)
+
+// Replicate dispatches the JournalServer.Replicate API.
+func (srv *Service) Replicate(stream pb.Journal_ReplicateServer) error {
+	var req, err = stream.Recv()
+	if err != nil {
+		return err
+	} else if err = req.Validate(); err != nil {
+		return err
+	}
+
+	var res resolution
+	res, err = srv.resolver.resolve(resolveArgs{
+		ctx:                   stream.Context(),
+		journal:               req.Journal,
+		mayProxy:              false,
+		requirePrimary:        false,
+		requireFullAssignment: true,
+		proxyHeader:           req.Header,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Require that the request Route is equivalent to the Route we resolved to.
+	if res.status == pb.Status_OK && !res.Header.Route.Equivalent(&req.Header.Route) {
+		res.status = pb.Status_WRONG_ROUTE
+	}
+	if res.status != pb.Status_OK {
+		return stream.Send(&pb.ReplicateResponse{
+			Status: res.status,
+			Header: &res.Header,
+		})
+	}
+
+	var spool fragment.Spool
+	if spool, err = acquireSpool(stream.Context(), res.replica, false); err != nil {
+		return err
+	}
+	spool, err = serveReplicate(stream, req, spool)
+
+	// Roll-back any uncommitted content, and release ownership of Spool.
+	spool.MustApply(&pb.ReplicateRequest{Proposal: &spool.Fragment.Fragment})
+	res.replica.spoolCh <- spool
+
+	if err != nil {
+		log.WithFields(log.Fields{"err": err, "req": req}).Warn("failed to serve Replicate")
+	}
+	return err
+}
+
+// serveReplicate evaluates a client's Replicate RPC against the local Spool.
+func serveReplicate(stream pb.Journal_ReplicateServer, req *pb.ReplicateRequest, spool fragment.Spool) (fragment.Spool, error) {
+	for {
+		var resp, err = spool.Apply(req, false)
+		if err != nil {
+			return spool, err
+		}
+
+		if req.Acknowledge {
+			if err = stream.SendMsg(&resp); err != nil {
+				return spool, err
+			}
+		} else if resp.Status != pb.Status_OK {
+			return spool, fmt.Errorf("no ack requested but status != OK: %s", &resp)
+		}
+
+		if req, err = stream.Recv(); err == io.EOF {
+			return spool, nil
+		} else if err != nil {
+			return spool, err
+		} else if err = req.Validate(); err != nil {
+			return spool, err
+		}
+	}
+}

--- a/v2/pkg/broker/replicate_api_test.go
+++ b/v2/pkg/broker/replicate_api_test.go
@@ -1,0 +1,176 @@
+package broker
+
+import (
+	"context"
+	"io"
+
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+)
+
+type ReplicateSuite struct{}
+
+func (s *ReplicateSuite) TestStreamAndCommit(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	newTestJournal(c, ks, "a/journal", 2, peer.id, broker.id)
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+	var stream, _ = broker.MustClient().Replicate(pb.WithDispatchDefault(ctx))
+
+	// Initial sync.
+	c.Check(stream.Send(&pb.ReplicateRequest{
+		Journal: "a/journal",
+		Header:  &res.Header,
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: true,
+	}), gc.IsNil)
+	expectReplResponse(c, stream, &pb.ReplicateResponse{Status: pb.Status_OK})
+
+	// Replicate content.
+	c.Check(stream.Send(&pb.ReplicateRequest{Content: []byte("foobar"), ContentDelta: 0}), gc.IsNil)
+	c.Check(stream.Send(&pb.ReplicateRequest{Content: []byte("bazbing"), ContentDelta: 6}), gc.IsNil)
+
+	// Precondition: content not observable in the Fragment index.
+	c.Check(res.replica.index.EndOffset(), gc.Equals, int64(0))
+
+	// Commit.
+	c.Check(stream.Send(&pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            0,
+			End:              13,
+			Sum:              pb.SHA1SumOf("foobarbazbing"),
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: true,
+	}), gc.IsNil)
+	expectReplResponse(c, stream, &pb.ReplicateResponse{Status: pb.Status_OK})
+
+	// Post-condition: content is now observable.
+	c.Check(res.replica.index.EndOffset(), gc.Equals, int64(13))
+
+	// Send EOF and expect one.
+	c.Check(stream.CloseSend(), gc.IsNil)
+	var _, err = stream.Recv()
+	c.Check(err, gc.Equals, io.EOF)
+}
+
+func (s *ReplicateSuite) TestErrorCases(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	ctx = pb.WithDispatchDefault(ctx)
+
+	// Case: Resolution error (Journal not found).
+	var stream, _ = broker.MustClient().Replicate(ctx)
+	var res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "does/not/exist"})
+
+	c.Check(stream.Send(&pb.ReplicateRequest{
+		Journal: "does/not/exist",
+		Header:  &res.Header,
+		Proposal: &pb.Fragment{
+			Journal:          "does/not/exist",
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: true,
+	}), gc.IsNil)
+
+	expectReplResponse(c, stream, &pb.ReplicateResponse{
+		Status: pb.Status_JOURNAL_NOT_FOUND,
+		Header: &res.Header,
+	})
+
+	// Expect broker closes.
+	var _, err = stream.Recv()
+	c.Check(err, gc.Equals, io.EOF)
+
+	// Case: request Route doesn't match the broker's own resolution.
+	newTestJournal(c, ks, "a/journal", 2, peer.id, broker.id)
+	stream, _ = broker.MustClient().Replicate(ctx)
+	res, _ = broker.resolve(resolveArgs{ctx: ctx, journal: "a/journal"})
+
+	var hdr = res.Header
+	hdr.Route = pb.Route{Primary: -1}
+	hdr.Etcd.Revision -= 1
+
+	c.Check(stream.Send(&pb.ReplicateRequest{
+		Journal: "a/journal",
+		Header:  &hdr,
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: true,
+	}), gc.IsNil)
+
+	expectReplResponse(c, stream, &pb.ReplicateResponse{
+		Status: pb.Status_WRONG_ROUTE,
+		Header: &res.Header,
+	})
+
+	// Expect broker closes.
+	_, err = stream.Recv()
+	c.Check(err, gc.Equals, io.EOF)
+
+	// Case: acknowledged proposal doesn't match.
+	stream, _ = broker.MustClient().Replicate(ctx)
+
+	c.Check(stream.Send(&pb.ReplicateRequest{
+		Journal: "a/journal",
+		Header:  &res.Header,
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            1234,
+			End:              5678,
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: true,
+	}), gc.IsNil)
+
+	expectReplResponse(c, stream, &pb.ReplicateResponse{
+		Status: pb.Status_FRAGMENT_MISMATCH,
+		Fragment: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            5678, // Spool is rolled forward.
+			End:              5678,
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+	})
+
+	// |stream| remains open.
+
+	// Case: proposal is made without Acknowledge set, and fails to apply.
+	c.Check(stream.Send(&pb.ReplicateRequest{
+		Proposal: &pb.Fragment{
+			Journal:          "a/journal",
+			Begin:            1234,
+			End:              5678,
+			CompressionCodec: pb.CompressionCodec_NONE,
+		},
+		Acknowledge: false,
+	}), gc.IsNil)
+
+	// Expect broker closes.
+	_, err = stream.Recv()
+	c.Check(err, gc.ErrorMatches, `.* no ack requested but status != OK: status:FRAGMENT_MISMATCH .*`)
+}
+
+func expectReplResponse(c *gc.C, stream pb.Journal_ReplicateClient, expect *pb.ReplicateResponse) {
+	var resp, err = stream.Recv()
+	c.Check(err, gc.IsNil)
+	c.Check(resp, gc.DeepEquals, expect)
+}
+
+var _ = gc.Suite(&ReplicateSuite{})

--- a/v2/pkg/broker/resolver.go
+++ b/v2/pkg/broker/resolver.go
@@ -1,0 +1,208 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/LiveRamp/gazette/v2/pkg/allocator"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+)
+
+// resolver maps journals to responsible broker instances and, potentially, a local replica.
+type resolver struct {
+	state      *allocator.State
+	replicas   map[pb.Journal]*replica
+	newReplica func(pb.Journal) *replica
+}
+
+func newResolver(state *allocator.State, newReplica func(pb.Journal) *replica) *resolver {
+	var r = &resolver{
+		state:      state,
+		replicas:   make(map[pb.Journal]*replica),
+		newReplica: newReplica,
+	}
+
+	state.KS.Mu.Lock()
+	state.KS.Observers = append(state.KS.Observers, r.updateResolutions)
+	state.KS.Mu.Unlock()
+
+	return r
+}
+
+type resolveArgs struct {
+	ctx context.Context
+	// Journal to be dispatched.
+	journal pb.Journal
+	// Whether we may proxy to another broker.
+	mayProxy bool
+	// Whether we require the primary broker of the journal.
+	requirePrimary bool
+	// Whether we require that the journal be fully assigned, or will otherwise
+	// tolerate fewer broker assignments than the desired journal replication.
+	requireFullAssignment bool
+	// Minimum Etcd Revision to have read through, before generating a resolution.
+	minEtcdRevision int64
+	// Optional Header attached to the request from a proxying peer.
+	proxyHeader *pb.Header
+}
+
+type resolution struct {
+	status pb.Status
+	// Header defines the selected broker ID, effective Etcd Revision,
+	// and Journal Route of the resolution.
+	pb.Header
+	// JournalSpec of the Journal at the current Etcd Revision.
+	journalSpec *pb.JournalSpec
+	// replica of the local assigned journal, iff the journal was resolved to this broker
+	// (as opposed to a remote peer).
+	replica *replica
+}
+
+func (r *resolver) resolve(args resolveArgs) (res resolution, err error) {
+	var ks = r.state.KS
+	defer ks.Mu.RUnlock()
+	ks.Mu.RLock()
+
+	var localID pb.ProcessSpec_ID
+
+	if r.state.LocalMemberInd != -1 {
+		localID = r.state.Members[r.state.LocalMemberInd].
+			Decoded.(allocator.Member).MemberValue.(*pb.BrokerSpec).Id
+	} else {
+		// During graceful shutdown, we may still serve requests even after our
+		// local member key has been removed from Etcd. We don't want to outright
+		// fail these requests as we can usefully proxy them. Use a placeholder
+		// to ensure |localID| doesn't match ProcessSpec_ID{}, and for logging.
+		localID = pb.ProcessSpec_ID{Zone: "local BrokerSpec", Suffix: "missing from Etcd"}
+	}
+
+	if hdr := args.proxyHeader; hdr != nil {
+		// Sanity check the proxy broker is using our same Etcd cluster.
+		if hdr.Etcd.ClusterId != ks.Header.ClusterId {
+			err = fmt.Errorf("proxied request Etcd ClusterId doesn't match our own (%d vs %d)",
+				hdr.Etcd.ClusterId, ks.Header.ClusterId)
+			return
+		}
+		// Sanity-check that the proxy broker reached the intended recipient.
+		if hdr.ProcessId != (pb.ProcessSpec_ID{}) && hdr.ProcessId != localID {
+			err = fmt.Errorf("proxied request ProcessId doesn't match our own (%s vs %s)",
+				&hdr.ProcessId, &localID)
+			return
+		}
+		// We want to wait for the greater of a |proxyHeader| or |minEtcdRevision|.
+		if args.proxyHeader.Etcd.Revision > args.minEtcdRevision {
+			args.minEtcdRevision = args.proxyHeader.Etcd.Revision
+		}
+	}
+
+	if args.minEtcdRevision > ks.Header.Revision {
+		addTrace(args.ctx, " ... at revision %d, but want at least %d",
+			ks.Header.Revision, args.minEtcdRevision)
+
+		if err = ks.WaitForRevision(args.ctx, args.minEtcdRevision); err != nil {
+			return
+		}
+		addTrace(args.ctx, "WaitForRevision(%d) => %d",
+			args.minEtcdRevision, ks.Header.Revision)
+	}
+	res.Etcd = pb.FromEtcdResponseHeader(ks.Header)
+
+	// Extract JournalSpec.
+	if item, ok := allocator.LookupItem(ks, args.journal.String()); ok {
+		res.journalSpec = item.ItemValue.(*pb.JournalSpec)
+	}
+	// Extract Route.
+	var assignments = ks.KeyValues.Prefixed(
+		allocator.ItemAssignmentsPrefix(ks, args.journal.String()))
+
+	res.Route.Init(assignments)
+	res.Route.AttachEndpoints(ks)
+
+	// Select a definite ProcessID if we require the primary and there is one,
+	// or if we're a member of the Route (and authoritative).
+	if args.requirePrimary && res.Route.Primary != -1 {
+		res.ProcessId = res.Route.Members[res.Route.Primary]
+	} else if !args.requirePrimary {
+		for i := range res.Route.Members {
+			if res.Route.Members[i] == localID {
+				res.ProcessId = localID
+			}
+		}
+	}
+
+	// If we're authoritative, attach our replica to the resolution.
+	if res.ProcessId == localID {
+		res.replica = r.replicas[args.journal]
+	}
+
+	// Select a response Status code.
+	if res.journalSpec == nil {
+		res.status = pb.Status_JOURNAL_NOT_FOUND
+	} else if args.requirePrimary && res.Route.Primary == -1 {
+		res.status = pb.Status_NO_JOURNAL_PRIMARY_BROKER
+	} else if len(res.Route.Members) == 0 {
+		res.status = pb.Status_INSUFFICIENT_JOURNAL_BROKERS
+	} else if args.requireFullAssignment && len(res.Route.Members) < int(res.journalSpec.Replication) {
+		res.status = pb.Status_INSUFFICIENT_JOURNAL_BROKERS
+	} else if !args.mayProxy && res.ProcessId != localID {
+		if args.requirePrimary {
+			res.status = pb.Status_NOT_JOURNAL_PRIMARY_BROKER
+		} else {
+			res.status = pb.Status_NOT_JOURNAL_BROKER
+		}
+	} else {
+		res.status = pb.Status_OK
+	}
+
+	// If we're returning an error, the effective ProcessId is ourselves
+	// (since we authored the error response).
+	if res.status != pb.Status_OK {
+		res.ProcessId = localID
+	}
+
+	addTrace(args.ctx, "resolve(%s) => %s, local: %t, header: %s",
+		args.journal, res.status, res.replica != nil, &res.Header)
+
+	return
+}
+
+// updateResolutions, by virtue of being a KeySpace.Observer, expects that the
+// KeySpace.Mu Lock is held.
+func (r *resolver) updateResolutions() {
+	var next = make(map[pb.Journal]*replica, len(r.state.LocalItems))
+
+	for _, li := range r.state.LocalItems {
+		var item = li.Item.Decoded.(allocator.Item)
+		var assignment = li.Assignments[li.Index].Decoded.(allocator.Assignment)
+		var name = pb.Journal(item.ID)
+
+		var rep *replica
+		var ok bool
+
+		if rep, ok = r.replicas[name]; ok {
+			next[name] = rep
+			delete(r.replicas, name)
+		} else {
+			rep = r.newReplica(name)
+			next[name] = rep
+		}
+
+		if assignment.Slot == 0 && !item.IsConsistent(keyspace.KeyValue{}, li.Assignments) {
+			// Attempt to signal maintenanceLoop that the journal should be pulsed.
+			select {
+			case rep.signalMaintenanceCh <- struct{}{}:
+			default: // Pass (non-blocking).
+			}
+		}
+	}
+
+	var prev = r.replicas
+	r.replicas = next
+
+	for _, rep := range prev {
+		// Signal maintenanceLoop to stop the replica.
+		close(rep.signalMaintenanceCh)
+	}
+	return
+}

--- a/v2/pkg/broker/resolver_test.go
+++ b/v2/pkg/broker/resolver_test.go
@@ -1,0 +1,199 @@
+package broker
+
+import (
+	"context"
+	"time"
+
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+)
+
+type ResolverSuite struct{}
+
+func (s *ResolverSuite) TestResolutionCases(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+	var peer = newMockBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "peer", Suffix: "broker"})
+
+	var mkRoute = func(i int, b ...*testBroker) (rt pb.Route) {
+		rt = pb.Route{Primary: int32(i)}
+		for i := range b {
+			rt.Members = append(rt.Members, b[i].id)
+			rt.Endpoints = append(rt.Endpoints, b[i].Endpoint())
+		}
+		return
+	}
+	newTestJournal(c, ks, "primary/journal", 2, broker.id, peer.id)
+	newTestJournal(c, ks, "replica/journal", 2, peer.id, broker.id)
+	newTestJournal(c, ks, "no/primary/journal", 2, pb.ProcessSpec_ID{}, broker.id, peer.id)
+	newTestJournal(c, ks, "no/brokers/journal", 2)
+	newTestJournal(c, ks, "insufficient/brokers/journal", 3, broker.id, peer.id)
+	newTestJournal(c, ks, "peer/only/journal", 1, peer.id)
+
+	// Expect a replica was created for each journal |broker| is responsible for.
+	c.Check(broker.resolver.replicas, gc.HasLen, 4)
+
+	// Case: simple resolution of local replica.
+	var r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "replica/journal"})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+	// Expect the local replica is attached.
+	c.Check(r.replica, gc.Equals, broker.resolver.replicas["replica/journal"])
+	// As is the JournalSpec
+	c.Check(r.journalSpec.Name, gc.Equals, pb.Journal("replica/journal"))
+	// And a Header having the correct Route (with Endpoints), Etcd header, and responsible broker ID.
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(1, broker, peer))
+	c.Check(r.Header.Etcd, gc.DeepEquals, pb.FromEtcdResponseHeader(ks.Header))
+
+	// Case: primary is required, and we are primary.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "primary/journal", requirePrimary: true})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id)
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(0, broker, peer))
+
+	// Case: primary is required, we are not primary, and may not proxy.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "replica/journal", requirePrimary: true})
+	c.Check(r.status, gc.Equals, pb.Status_NOT_JOURNAL_PRIMARY_BROKER)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id) // Still |broker|, since it authored the response.
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(1, broker, peer))
+	c.Check(r.replica, gc.IsNil)
+
+	// Case: primary is required, and we may proxy.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "replica/journal", requirePrimary: true, mayProxy: true})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+	c.Check(r.Header.ProcessId, gc.Equals, peer.id) // This time, |peer| is the resolved broker.
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(1, broker, peer))
+
+	// Case: primary is required, we may proxy, but there is no primary.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "no/primary/journal", requirePrimary: true, mayProxy: true})
+	c.Check(r.status, gc.Equals, pb.Status_NO_JOURNAL_PRIMARY_BROKER)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id)
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(-1, broker, peer))
+
+	// Case: we may not proxy, and are not a replica.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "peer/only/journal"})
+	c.Check(r.status, gc.Equals, pb.Status_NOT_JOURNAL_BROKER)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id)
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(0, peer))
+
+	// Case: we may proxy, and are not a replica.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "peer/only/journal", mayProxy: true})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+	c.Check(r.Header.ProcessId, gc.Equals, pb.ProcessSpec_ID{}) // Primary not required and non-local => no ID.
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(0, peer))
+
+	// Case: we require the journal be fully assigned, and it is.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "replica/journal", requireFullAssignment: true})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id)
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(1, broker, peer))
+
+	// Case: we require the journal be fully assigned, and it isn't.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "insufficient/brokers/journal", requireFullAssignment: true})
+	c.Check(r.status, gc.Equals, pb.Status_INSUFFICIENT_JOURNAL_BROKERS)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id)
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(0, broker, peer))
+
+	// Case: the journal has no brokers.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "no/brokers/journal", mayProxy: true})
+	c.Check(r.status, gc.Equals, pb.Status_INSUFFICIENT_JOURNAL_BROKERS)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id)
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(-1))
+
+	// Case: the journal doesn't exist.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "does/not/exist"})
+	c.Check(r.status, gc.Equals, pb.Status_JOURNAL_NOT_FOUND)
+	c.Check(r.Header.ProcessId, gc.Equals, broker.id)
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(-1))
+
+	// Case: our broker key has been removed.
+	c.Check(ks.Apply(etcdEvent(ks, "del", broker.state.LocalKey, "")), gc.IsNil)
+
+	// Subcase 1: We can still resolve for peer journals.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "peer/only/journal", mayProxy: true})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+	c.Check(r.Header.ProcessId, gc.Equals, pb.ProcessSpec_ID{})
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(0, peer))
+
+	// Subcase 2: We use a placeholder ProcessId.
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "peer/only/journal"})
+	c.Check(r.status, gc.Equals, pb.Status_NOT_JOURNAL_BROKER)
+	c.Check(r.Header.ProcessId, gc.Equals, pb.ProcessSpec_ID{Zone: "local BrokerSpec", Suffix: "missing from Etcd"})
+	c.Check(r.Header.Route, gc.DeepEquals, mkRoute(0, peer))
+}
+
+func (s *ResolverSuite) TestFutureRevisionCasesWithProxyHeader(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+
+	// Case: Request a resolution, passing along a proxyHeader fixture which
+	// references a future Etcd Revision. In the background, arrange for that Etcd
+	// update to be delivered.
+
+	var hdr = pb.Header{
+		ProcessId: broker.id,
+		Route: pb.Route{
+			Members:   []pb.ProcessSpec_ID{broker.id},
+			Primary:   0,
+			Endpoints: []pb.Endpoint{broker.Endpoint()},
+		},
+		Etcd: pb.FromEtcdResponseHeader(ks.Header),
+	}
+	hdr.Etcd.Revision += 1
+
+	go func() {
+		time.Sleep(time.Millisecond)
+		newTestJournal(c, ks, "journal/one", 1, broker.id)
+	}()
+
+	// Expect the resolution succeeds, despite the journal not yet existing.
+	var r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "journal/one", proxyHeader: &hdr})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+	c.Check(r.Header, gc.DeepEquals, hdr)
+
+	// Case: this time, specify a future revision via |minEtcdRevision|. Expect that also works.
+	go func() {
+		time.Sleep(time.Millisecond)
+		newTestJournal(c, ks, "journal/two", 1, broker.id)
+	}()
+
+	r, _ = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "journal/two", minEtcdRevision: ks.Header.Revision + 1})
+	c.Check(r.status, gc.Equals, pb.Status_OK)
+
+	// Case: finally, specify a future revision which doesn't come about and cancel the context.
+	go cancel()
+
+	var _, err = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "journal/three", minEtcdRevision: ks.Header.Revision + 1})
+	c.Check(err, gc.Equals, context.Canceled)
+}
+
+func (s *ResolverSuite) TestProxyHeaderErrorCases(c *gc.C) {
+	var ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	var ks = NewKeySpace("/root")
+	var broker = newTestBroker(c, ctx, ks, pb.ProcessSpec_ID{Zone: "local", Suffix: "broker"})
+
+	var proxy = pb.Header{
+		ProcessId: pb.ProcessSpec_ID{Zone: "other", Suffix: "id"},
+		Route:     pb.Route{Primary: -1},
+		Etcd:      pb.FromEtcdResponseHeader(ks.Header),
+	}
+
+	// Case: proxy header references a broker other than this one.
+	var _, err = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "a/journal", proxyHeader: &proxy})
+	c.Check(err, gc.ErrorMatches, `proxied request ProcessId doesn't match our own \(zone.*`)
+	proxy.ProcessId = broker.id
+
+	// Case: proxy header references a ClusterId other than our own.
+	proxy.Etcd.ClusterId = 8675309
+	_, err = broker.resolver.resolve(resolveArgs{ctx: ctx, journal: "a/journal", proxyHeader: &proxy})
+	c.Check(err, gc.ErrorMatches, `proxied request Etcd ClusterId doesn't match our own \(\d+.*`)
+}
+
+var _ = gc.Suite(&ResolverSuite{})

--- a/v2/pkg/broker/service.go
+++ b/v2/pkg/broker/service.go
@@ -1,0 +1,59 @@
+package broker
+
+import (
+	"context"
+
+	"github.com/LiveRamp/gazette/v2/pkg/allocator"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	"github.com/coreos/etcd/clientv3"
+	"golang.org/x/net/trace"
+)
+
+// Service is the top-level runtime concern of a Gazette Broker process. It
+// drives local journal handling in response to allocator.State, powers
+// journal resolution, and is also an implementation of protocol.JournalServer.
+type Service struct {
+	jc       pb.JournalClient
+	etcd     clientv3.KV
+	resolver *resolver
+}
+
+// NewService constructs a new broker Service, driven by allocator.State.
+func NewService(state *allocator.State, jc pb.JournalClient, etcd clientv3.KV) *Service {
+	var svc = &Service{jc: jc, etcd: etcd}
+
+	svc.resolver = newResolver(state, func(journal pb.Journal) *replica {
+		var rep = newReplica(journal)
+		go maintenanceLoop(rep, state.KS, pb.NewRoutedJournalClient(jc, svc), etcd)
+		return rep
+	})
+	return svc
+}
+
+func addTrace(ctx context.Context, format string, args ...interface{}) {
+	if tr, ok := trace.FromContext(ctx); ok {
+		tr.LazyPrintf(format, args...)
+	}
+}
+
+// Route an item using the Service resolver. Route implements the
+// protocol.DispatchRouter interface, and enables usages of
+// protocol.WithDispatchItemRoute (eg, `client` & `http_gateway` packages) to
+// resolve items via the Service resolver.
+func (svc *Service) Route(ctx context.Context, item string) pb.Route {
+	var res, err = svc.resolver.resolve(resolveArgs{
+		ctx:      ctx,
+		journal:  pb.Journal(item),
+		mayProxy: true,
+	})
+	if err != nil {
+		panic(err) // Cannot err because we use neither minEtcdRevision nor proxyHeader.
+	}
+	// If Status != OK, Route will be zero-valued, which directs dispatcher
+	// to use the default service address (localhost), which will then re-run
+	// resolution and generate a proper error message for the client.
+	return res.Route
+}
+
+// UpdateRoute is a no-op implementation of protocol.DispatchRouter.
+func (svc *Service) UpdateRoute(string, *pb.Route) {} // No-op.

--- a/v2/pkg/broker/test_support_test.go
+++ b/v2/pkg/broker/test_support_test.go
@@ -1,0 +1,153 @@
+package broker
+
+import (
+	"context"
+	"time"
+
+	"github.com/LiveRamp/gazette/v2/pkg/allocator"
+	"github.com/LiveRamp/gazette/v2/pkg/broker/teststub"
+	"github.com/LiveRamp/gazette/v2/pkg/keyspace"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	gc "github.com/go-check/check"
+)
+
+type testBroker struct {
+	id pb.ProcessSpec_ID
+	*teststub.Server
+
+	*teststub.Broker // nil if not built with newMockBroker.
+	*resolver        // nil if not built with newTestBroker.
+}
+
+func newTestBroker(c *gc.C, ctx context.Context, ks *keyspace.KeySpace, id pb.ProcessSpec_ID) *testBroker {
+	var state = allocator.NewObservedState(ks, allocator.MemberKey(ks, id.Zone, id.Suffix))
+	var res = newResolver(state, newReplica)
+
+	var svc = &Service{resolver: res}
+	var srv = teststub.NewServer(c, ctx, svc)
+	svc.jc = srv.MustClient()
+
+	c.Check(ks.Apply(etcdEvent(ks, "put", state.LocalKey, (&pb.BrokerSpec{
+		ProcessSpec: pb.ProcessSpec{
+			Id:       id,
+			Endpoint: srv.Endpoint(),
+		},
+	}).MarshalString())), gc.IsNil)
+
+	return &testBroker{
+		id:       id,
+		Server:   srv,
+		resolver: res,
+	}
+}
+
+func newMockBroker(c *gc.C, ctx context.Context, ks *keyspace.KeySpace, id pb.ProcessSpec_ID) *testBroker {
+	var broker = teststub.NewBroker(c, ctx)
+	var key = allocator.MemberKey(ks, id.Zone, id.Suffix)
+
+	c.Check(ks.Apply(etcdEvent(ks, "put", key, (&pb.BrokerSpec{
+		ProcessSpec: pb.ProcessSpec{
+			Id:       id,
+			Endpoint: broker.Server.Endpoint(),
+		},
+	}).MarshalString())), gc.IsNil)
+
+	return &testBroker{
+		id:     id,
+		Server: broker.Server,
+		Broker: broker,
+	}
+}
+
+func newTestJournal(c *gc.C, ks *keyspace.KeySpace, journal pb.Journal, replication int32, ids ...pb.ProcessSpec_ID) {
+	var tkv []string
+
+	// Create JournalSpec.
+	tkv = append(tkv, "put",
+		allocator.ItemKey(ks, journal.String()),
+		(&pb.JournalSpec{
+			Name:        journal,
+			Replication: replication,
+			Fragment: pb.JournalSpec_Fragment{
+				Length:           1024,
+				RefreshInterval:  time.Second,
+				CompressionCodec: pb.CompressionCodec_SNAPPY,
+			},
+		}).MarshalString())
+
+	// Create broker assignments.
+	for slot, id := range ids {
+		if id == (pb.ProcessSpec_ID{}) {
+			continue
+		}
+
+		var key = allocator.AssignmentKey(ks, allocator.Assignment{
+			ItemID:       journal.String(),
+			MemberZone:   id.Zone,
+			MemberSuffix: id.Suffix,
+			Slot:         slot,
+		})
+
+		tkv = append(tkv, "put", key, "")
+	}
+	c.Check(ks.Apply(etcdEvent(ks, tkv...)), gc.IsNil)
+}
+
+func etcdEvent(ks *keyspace.KeySpace, typeKeyValue ...string) clientv3.WatchResponse {
+	if len(typeKeyValue)%3 != 0 {
+		panic("not type/key/value")
+	}
+
+	defer ks.Mu.RUnlock()
+	ks.Mu.RLock()
+
+	var resp = clientv3.WatchResponse{
+		Header: etcdserverpb.ResponseHeader{
+			ClusterId: 0xfeedbeef,
+			MemberId:  0x01234567,
+			RaftTerm:  0x11223344,
+			Revision:  ks.Header.Revision + 1,
+		},
+	}
+
+	for i := 0; i != len(typeKeyValue); i += 3 {
+		var typ, key, value = typeKeyValue[i], typeKeyValue[i+1], typeKeyValue[i+2]
+
+		var event = &clientv3.Event{
+			Kv: &mvccpb.KeyValue{
+				Key:         []byte(key),
+				Value:       []byte(value),
+				ModRevision: ks.Header.Revision + 1,
+			},
+		}
+		var ind, ok = ks.Search(key)
+
+		switch typ {
+		case "put":
+			event.Type = clientv3.EventTypePut
+		case "del":
+			event.Type = clientv3.EventTypeDelete
+			if !ok {
+				panic("!ok")
+			}
+		default:
+			panic(typ)
+		}
+
+		if ok {
+			var cur = ks.KeyValues[ind].Raw
+			event.Kv.CreateRevision = cur.CreateRevision
+			event.Kv.Version = cur.Version + 1
+			event.Kv.Lease = cur.Lease
+		} else {
+			event.Kv.CreateRevision = event.Kv.ModRevision
+			event.Kv.Version = 1
+		}
+
+		resp.Events = append(resp.Events, event)
+	}
+	return resp
+}

--- a/v2/pkg/broker/teststub/broker.go
+++ b/v2/pkg/broker/teststub/broker.go
@@ -1,0 +1,213 @@
+package teststub
+
+import (
+	"context"
+	"io"
+	"net"
+
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+	gc "github.com/go-check/check"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// Server wraps a protocol.JournalServer with a gRPC server for use within tests.
+type Server struct {
+	c        *gc.C
+	ctx      context.Context
+	listener net.Listener
+	srv      *grpc.Server
+}
+
+// NewServer returns a local GRPC server wrapping the provided BrokerServer.
+func NewServer(c *gc.C, ctx context.Context, srv pb.JournalServer) *Server {
+	var l, err = net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, gc.IsNil)
+
+	var p = &Server{
+		c:        c,
+		ctx:      ctx,
+		listener: l,
+		srv:      grpc.NewServer(),
+	}
+
+	pb.RegisterJournalServer(p.srv, srv)
+	go p.srv.Serve(p.listener)
+
+	go func() {
+		<-ctx.Done()
+		p.srv.GracefulStop()
+	}()
+
+	return p
+}
+
+func (s *Server) Endpoint() pb.Endpoint {
+	return pb.Endpoint("http://" + s.listener.Addr().String() + "/path")
+}
+
+func (s *Server) Dial(ctx context.Context) (*grpc.ClientConn, error) {
+	return grpc.DialContext(ctx, s.listener.Addr().String(),
+		grpc.WithInsecure(),
+		grpc.WithBalancerName(pb.DispatcherGRPCBalancerName))
+}
+
+func (s *Server) MustConn() *grpc.ClientConn {
+	var conn, err = s.Dial(s.ctx)
+	s.c.Assert(err, gc.IsNil)
+	return conn
+}
+
+func (s *Server) MustClient() pb.JournalClient {
+	return pb.NewJournalClient(s.MustConn())
+}
+
+// Broker stubs the read and write loops of broker RPCs, routing them onto
+// channels which can be synchronously read and written within test bodies.
+type Broker struct {
+	*Server
+
+	ReplReqCh  chan *pb.ReplicateRequest
+	ReplRespCh chan *pb.ReplicateResponse
+
+	ReadReqCh  chan *pb.ReadRequest
+	ReadRespCh chan *pb.ReadResponse
+
+	AppendReqCh  chan *pb.AppendRequest
+	AppendRespCh chan *pb.AppendResponse
+
+	ListFunc  func(context.Context, *pb.ListRequest) (*pb.ListResponse, error)
+	ApplyFunc func(context.Context, *pb.ApplyRequest) (*pb.ApplyResponse, error)
+
+	ErrCh chan error
+}
+
+// NewBroker returns a Broker instance served by a local GRPC server.
+func NewBroker(c *gc.C, ctx context.Context) *Broker {
+	var p = &Broker{
+		ReplReqCh:    make(chan *pb.ReplicateRequest),
+		ReplRespCh:   make(chan *pb.ReplicateResponse),
+		ReadReqCh:    make(chan *pb.ReadRequest),
+		ReadRespCh:   make(chan *pb.ReadResponse),
+		AppendReqCh:  make(chan *pb.AppendRequest),
+		AppendRespCh: make(chan *pb.AppendResponse),
+		ErrCh:        make(chan error),
+	}
+	p.Server = NewServer(c, ctx, p)
+	return p
+}
+
+func (p *Broker) Replicate(srv pb.Journal_ReplicateServer) error {
+	// Start a read loop of requests from |srv|.
+	go func() {
+		log.WithField("id", p.Endpoint()).Info("replicate read loop started")
+		for done := false; !done; {
+			var msg, err = srv.Recv()
+
+			if err == io.EOF {
+				msg, err, done = nil, nil, true
+			} else if err != nil {
+				done = true
+
+				p.c.Check(err, gc.ErrorMatches, `rpc error: code = Canceled desc = context canceled`)
+			}
+
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "msg": msg, "err": err, "done": done}).Info("read")
+
+			select {
+			case p.ReplReqCh <- msg:
+				// Pass.
+			case <-p.ctx.Done():
+				done = true
+			}
+		}
+	}()
+
+	for {
+		select {
+		case resp := <-p.ReplRespCh:
+			p.c.Check(srv.Send(resp), gc.IsNil)
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "resp": resp}).Info("sent")
+		case err := <-p.ErrCh:
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "err": err}).Info("closing")
+			return err
+		case <-p.ctx.Done():
+			log.WithFields(log.Fields{"ep": p.Endpoint()}).Info("cancelled")
+			return p.ctx.Err()
+		}
+	}
+}
+
+func (p *Broker) Read(req *pb.ReadRequest, srv pb.Journal_ReadServer) error {
+	select {
+	case p.ReadReqCh <- req:
+		// Pass.
+	case <-p.ctx.Done():
+		return p.ctx.Err()
+	}
+
+	for {
+		select {
+		case resp := <-p.ReadRespCh:
+			srv.Send(resp) // This may return cancelled context error.
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "resp": resp}).Info("sent")
+		case err := <-p.ErrCh:
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "err": err}).Info("closing")
+			return err
+		case <-p.ctx.Done():
+			log.WithFields(log.Fields{"ep": p.Endpoint()}).Info("cancelled")
+			return p.ctx.Err()
+		}
+	}
+}
+
+func (p *Broker) Append(srv pb.Journal_AppendServer) error {
+	// Start a read loop of requests from |srv|.
+	go func() {
+		log.WithField("ep", p.Endpoint()).Info("append read loop started")
+		for done := false; !done; {
+			var msg, err = srv.Recv()
+
+			if err == io.EOF {
+				msg, err, done = nil, nil, true
+			} else if err != nil {
+				done = true
+
+				p.c.Check(err, gc.ErrorMatches, `rpc error: code = Canceled desc = context canceled`)
+			}
+
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "msg": msg, "err": err, "done": done}).Info("read")
+
+			select {
+			case p.AppendReqCh <- msg:
+				// Pass.
+			case <-p.ctx.Done():
+				done = true
+			}
+		}
+	}()
+
+	for {
+		select {
+		case resp := <-p.AppendRespCh:
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "resp": resp}).Info("sending")
+			return srv.SendAndClose(resp)
+		case err := <-p.ErrCh:
+			log.WithFields(log.Fields{"ep": p.Endpoint(), "err": err}).Info("closing")
+			return err
+		case <-p.ctx.Done():
+			log.WithFields(log.Fields{"ep": p.Endpoint()}).Info("cancelled")
+			return p.ctx.Err()
+		}
+	}
+}
+
+func (p *Broker) List(ctx context.Context, req *pb.ListRequest) (*pb.ListResponse, error) {
+	return p.ListFunc(ctx, req)
+}
+
+func (p *Broker) Apply(ctx context.Context, req *pb.ApplyRequest) (*pb.ApplyResponse, error) {
+	return p.ApplyFunc(ctx, req)
+}
+
+func init() { pb.RegisterGRPCDispatcher("local") }


### PR DESCRIPTION
Package broker implements the broker runtime and protocol.BrokerServer
Read, Append, and Replicate APIs. Its `pipeline` type manages the
coordination of write transactions, and `resolver` the mapping of
journal names to Routes of responsible brokers. `replica` is a top-level
collection of runtime state and maintenance tasks associated with the processing
of a journal. gRPC proxy support is also implemented by this package.

Issue #72

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/90)
<!-- Reviewable:end -->
