### PR TITLE
Skip building the RocksDB static library

### DIFF
--- a/v2/build/Dockerfile
+++ b/v2/build/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -L -o /opt/rocksdb.tgz \
  && rm /opt/rocksdb.tgz \
  && cd /opt/rocksdb \
  && USE_SSE=1 DEBUG_LEVEL=0 USE_RTTI=1 make shared_lib tools -j$(nproc) \
- && make install -j$(nproc) \
+ && make install-shared -j$(nproc) \
  && cp ldb sst_dump /usr/local/bin \
  && rm -r /opt/rocksdb \
  && ldconfig


### PR DESCRIPTION
Gazette only needs the RocksDB shared library, but the "install" make
target also builds and installs the static libraries [1]. Switching to
"install-shared" reduces the layer build time and the final size of the
image.

[1]: https://github.com/facebook/rocksdb/blob/5089e121166c46956a8a21c8ef967f1896c239de/Makefile#L1550

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/108)
<!-- Reviewable:end -->
