### PR TITLE
Introduce "vendor" image as cache

### DIFF
--- a/v2/build/Dockerfile
+++ b/v2/build/Dockerfile
@@ -44,8 +44,9 @@ RUN curl -L -o /opt/rocksdb.tgz \
  && ldconfig
 
 
-# Stage 2: Create a build image with dependencies & source, which is built and tested.
-FROM base as build
+# Stage 2: Create an image with the vendored dependencies, suitable for using
+# as a cache to speed up CI build times.
+FROM base as vendor
 
 ARG DEP_VERSION=v0.5.0
 
@@ -54,7 +55,13 @@ RUN curl -fsSL -o /usr/local/bin/dep \
  && chmod +x /usr/local/bin/dep
 
 COPY Gopkg.toml Gopkg.lock /go/src/github.com/LiveRamp/gazette/
-RUN cd /go/src/github.com/LiveRamp/gazette/ && dep ensure -vendor-only
+RUN cd /go/src/github.com/LiveRamp/gazette/ \
+ && dep ensure -vendor-only \
+ && rm -rf "$GOPATH/pkg/dep"
+
+
+# Stage 3: Create a build image with source, which is built and tested.
+FROM vendor as build
 
 # Copy, install, and test library and main packages.
 COPY v2/pkg /go/src/github.com/LiveRamp/gazette/v2/pkg
@@ -84,7 +91,7 @@ RUN go build \
     github.com/LiveRamp/gazette/v2/examples/word-count/counter
 
 
-# Stage 3: Pluck gazette binaries onto base.
+# Stage 4: Pluck gazette binaries onto base.
 FROM base as gazette
 
 COPY --from=build \
@@ -94,7 +101,7 @@ COPY --from=build \
     /go/bin/
 
 
-# Stage 4: Pluck example binaries onto gazette.
+# Stage 5: Pluck example binaries onto gazette.
 FROM gazette as examples
 
 COPY --from=build \

--- a/v2/build/all.sh
+++ b/v2/build/all.sh
@@ -18,7 +18,7 @@ if [[ ${CIRCLECI:-} = true ]]; then
     fi
 fi
 
-# Build the `vendor` image.
+# Build the `gazette-vendor` image.
 docker build ${ROOT} \
     --file ${ROOT}/v2/build/Dockerfile \
     --target vendor \
@@ -50,7 +50,7 @@ docker build ${ROOT} \
     --tag liveramp/gazette-examples:latest \
     ${CF_EXAMPLES:-}
 
-# Publish the `vendor` image which is used as a cache in CI builds.
+# Publish the `gazette-vendor` image which is used as a cache in CI builds.
 if [[ ${SHOULD_PUSH_VENDOR:-} = true && -n "${DOCKER_USER:-}" && -n "${DOCKER_PASS:-}" ]]; then
     # Temporarily disable xtrace to hide password ($DOCKER_PASS).
     set +x

--- a/v2/build/all.sh
+++ b/v2/build/all.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
-set -Eeu -o pipefail
+set -Eeux -o pipefail
 
 # Root directory of repository.
-ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+readonly ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
-docker pull liveramp/gazette-base:2.1.0
+readonly VENDOR_IMAGE="rupertchen/gazette-vendor:latest"
+if [[ ${CIRCLECI:-} = true ]]; then
+    docker pull "$VENDOR_IMAGE"
+
+    readonly CF_BUILD="--cache-from $VENDOR_IMAGE"
+    readonly CF_GAZETTE="--cache-from liveramp/gazette-build:latest"
+    readonly CF_EXAMPLES="--cache-from liveramp/gazette-build:latest --cache-from liveramp/gazette:latest"
+
+    if [[ $CIRCLE_BRANCH = "master" ]]; then
+        SHOULD_PUSH_VENDOR=true
+    fi
+fi
 
 # Build and test Gazette. This image includes all Gazette source, vendored
 # dependencies, compiled packages and binaries, and only completes after
@@ -13,7 +24,7 @@ docker build ${ROOT} \
     --file ${ROOT}/v2/build/Dockerfile \
     --target build \
     --tag liveramp/gazette-build:latest \
-    --cache-from liveramp/gazette-base:2.1.0
+    ${CF_BUILD:-}
 
 # Create the `gazette` image, which plucks the `gazette`, `gazctl` and
 # `run-consumer` onto a base runtime image.
@@ -21,7 +32,7 @@ docker build ${ROOT} \
     --file ${ROOT}/v2/build/Dockerfile \
     --target gazette \
     --tag liveramp/gazette:latest \
-    --cache-from liveramp/gazette-build:latest
+    ${CF_GAZETTE:-}
 
 # Create the `gazette-examples` image, which further plucks `stream-sum` and
 # `word-count` example artifacts onto the `gazette` image.
@@ -29,5 +40,20 @@ docker build ${ROOT} \
     --file ${ROOT}/v2/build/Dockerfile \
     --target examples \
     --tag liveramp/gazette-examples:latest \
-    --cache-from liveramp/gazette-build:latest \
-    --cache-from liveramp/gazette:latest
+    ${CF_EXAMPLES:-}
+
+# Publish vendor image which is used as a cache in CI builds.
+if [[ ${SHOULD_PUSH_VENDOR:-} = true && -n "${DOCKER_USER:-}" && -n "${DOCKER_PASS:-}" ]]; then
+    # Temporarily disable xtrace to hide password ($DOCKER_PASS).
+    set +x
+    echo "Log in to Docker as $DOCKER_USER"
+    echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
+    set -x
+
+    docker build . \
+      --file ./v2/build/Dockerfile \
+      --target vendor \
+      --tag "$VENDOR_IMAGE" \
+      --cache-from "$VENDOR_IMAGE"
+    docker push "$VENDOR_IMAGE"
+fi


### PR DESCRIPTION
The vendor image replaces the "base" image as an image cache during CI
builds. It contains everything that was in the "base" target and
additionally adds the vendored source consistent with the latest
Gopkg.lock on the master branch.

Use of "docker --cache-from" is removed from non-CI builds (e.g., local
developer builds) as docker's local build cache persists between
executions and better handles cached image invalidation.

Connects #117

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/118)
<!-- Reviewable:end -->
