### PR TITLE
client: consistent unwrapping of gRPC context errors

### DIFF
--- a/v2/pkg/broker/teststub/broker.go
+++ b/v2/pkg/broker/teststub/broker.go
@@ -81,7 +81,7 @@ func (p *Broker) Replicate(srv pb.Journal_ReplicateServer) error {
 			} else if err != nil {
 				done = true
 
-				p.c.Check(err, gc.ErrorMatches, `rpc error: code = Canceled desc = context canceled`)
+				p.c.Check(err, gc.ErrorMatches, `rpc error: code = (Canceled|DeadlineExceeded) .*`)
 			}
 
 			log.WithFields(log.Fields{"ep": p.Endpoint(), "msg": msg, "err": err, "done": done}).Info("read")

--- a/v2/pkg/client/appender.go
+++ b/v2/pkg/client/appender.go
@@ -52,6 +52,10 @@ func (a *Appender) Write(p []byte) (n int, err error) {
 	} else {
 		n = len(p)
 	}
+
+	if err != nil {
+		err = mapGRPCCtxErr(a.ctx, err)
+	}
 	return
 }
 
@@ -61,7 +65,7 @@ func (a *Appender) Write(p []byte) (n int, err error) {
 func (a *Appender) Close() (err error) {
 	// Send an empty chunk to signal commit of previously written content
 	if err = a.lazyInit(); err != nil {
-		return
+		// Pass.
 	} else if err = a.stream.SendMsg(new(pb.AppendRequest)); err != nil {
 		// Pass.
 	} else if err = a.stream.CloseSend(); err != nil {
@@ -83,6 +87,10 @@ func (a *Appender) Close() (err error) {
 		default:
 			err = errors.New(a.Response.Status.String())
 		}
+	}
+
+	if err != nil {
+		err = mapGRPCCtxErr(a.ctx, err)
 	}
 	return
 }

--- a/v2/pkg/client/list.go
+++ b/v2/pkg/client/list.go
@@ -66,7 +66,7 @@ func ListAll(ctx context.Context, client pb.JournalClient, req pb.ListRequest) (
 	for {
 		// List RPCs may be dispatched to any broker.
 		if r, err := client.List(pb.WithDispatchDefault(ctx), &req); err != nil {
-			return resp, err
+			return resp, mapGRPCCtxErr(ctx, err)
 		} else if err = r.Validate(); err != nil {
 			return resp, err
 		} else if r.Status != pb.Status_OK {

--- a/v2/pkg/client/list_test.go
+++ b/v2/pkg/client/list_test.go
@@ -72,6 +72,11 @@ func (s *ListSuite) TestListAllCases(c *gc.C) {
 
 	_, err = ListAll(context.Background(), broker.MustClient(), pb.ListRequest{Selector: selector})
 	c.Check(err, gc.ErrorMatches, `WRONG_ROUTE`)
+
+	// Case: It surfaces context.Canceled, rather than a gRPC error.
+	cancel()
+	_, err = ListAll(ctx, rjc, pb.ListRequest{Selector: selector, PageLimit: 10})
+	c.Check(err, gc.Equals, context.Canceled)
 }
 
 func (s *ListSuite) TestPolledList(c *gc.C) {

--- a/v2/pkg/client/retry_reader.go
+++ b/v2/pkg/client/retry_reader.go
@@ -156,7 +156,7 @@ func (rr *RetryReader) AdjustedSeek(offset int64, whence int, br *bufio.Reader) 
 
 	// Fast path: can we fulfill the seek by discarding a portion of buffered data?
 	if delta >= 0 && delta <= int64(br.Buffered()) {
-		br.Discard(int(delta))
+		_, _ = br.Discard(int(delta))
 		return offset, nil
 	}
 

--- a/v2/pkg/recoverylog/recorder_rocksdb_test.go
+++ b/v2/pkg/recoverylog/recorder_rocksdb_test.go
@@ -200,7 +200,7 @@ func (s *RecordedRocksDBSuite) TestCancelThenPlay(c *gc.C) {
 	cancelFn()
 
 	c.Check(r.player.Play(cancelCtx, FSMHints{Log: aRecoveryLog}, r.tmpdir, bk),
-		gc.ErrorMatches, `determining log head: rpc error: code = Canceled desc = context canceled`)
+		gc.ErrorMatches, `determining log head: context canceled`)
 
 	<-r.player.Done()
 }


### PR DESCRIPTION
Map gRPC errors having status that match local context errors, into the
well-known context error values. This simplifies error checks of client
responses.

Fixes #116

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/120)
<!-- Reviewable:end -->
