### PR TITLE
Use more specific tag for base image

### DIFF
--- a/v2/build/Dockerfile
+++ b/v2/build/Dockerfile
@@ -1,6 +1,6 @@
 # State 1: Create a base image which includes the Go toolchain,
 # RocksDB library, its tools, and dependencies.
-FROM golang:1.11 AS base
+FROM golang:1.11.4-stretch AS base
 
 ARG ROCKSDB_VERSION=5.14.2
 ARG ZSTD_VERSION=1.3.5


### PR DESCRIPTION
The tag "1.11" is expected to change regularly. When it does,
liveramp/gazette-vendor:latest is no longer valid as a cache source for
CI builds and results in much longer build times. Including the patch
version makes the tag more stable while adding the Debian release
differentiates it from Alpine-based images.