### PR TITLE
Support fragment store URL rewriting

### DIFF
--- a/v2/pkg/fragment/index.go
+++ b/v2/pkg/fragment/index.go
@@ -210,7 +210,7 @@ func WalkAllStores(ctx context.Context, name pb.Journal, stores []pb.FragmentSto
 	var set CoverSet
 
 	for _, store := range stores {
-		var err = List(ctx, store, name.String()+"/", func(f pb.Fragment) {
+		var err = List(ctx, store, name, func(f pb.Fragment) {
 			set, _ = set.Add(Fragment{Fragment: f})
 		})
 

--- a/v2/pkg/fragment/store_gcs.go
+++ b/v2/pkg/fragment/store_gcs.go
@@ -19,6 +19,8 @@ import (
 type gcsCfg struct {
 	bucket string
 	prefix string
+
+	rewriterCfg
 }
 
 func gcsSignGET(ep *url.URL, fragment pb.Fragment, d time.Duration) (string, error) {
@@ -29,7 +31,7 @@ func gcsSignGET(ep *url.URL, fragment pb.Fragment, d time.Duration) (string, err
 	opts.Method = "GET"
 	opts.Expires = time.Now().Add(d)
 
-	return storage.SignedURL(cfg.bucket, cfg.prefix+fragment.ContentPath(), &opts)
+	return storage.SignedURL(cfg.bucket, cfg.prefix+cfg.rewritePath(fragment.ContentPath()), &opts)
 }
 
 func gcsExists(ctx context.Context, ep *url.URL, fragment pb.Fragment) (exists bool, err error) {
@@ -37,7 +39,7 @@ func gcsExists(ctx context.Context, ep *url.URL, fragment pb.Fragment) (exists b
 	if err != nil {
 		return false, err
 	}
-	_, err = client.Bucket(cfg.bucket).Object(cfg.prefix + fragment.ContentPath()).Attrs(ctx)
+	_, err = client.Bucket(cfg.bucket).Object(cfg.prefix + cfg.rewritePath(fragment.ContentPath())).Attrs(ctx)
 	if err == nil {
 		exists = true
 	} else if err == storage.ErrObjectNotExist {
@@ -51,7 +53,7 @@ func gcsOpen(ctx context.Context, ep *url.URL, fragment pb.Fragment) (io.ReadClo
 	if err != nil {
 		return nil, err
 	}
-	return client.Bucket(cfg.bucket).Object(cfg.prefix + fragment.ContentPath()).NewReader(ctx)
+	return client.Bucket(cfg.bucket).Object(cfg.prefix + cfg.rewritePath(fragment.ContentPath())).NewReader(ctx)
 }
 
 func gcsPersist(ctx context.Context, ep *url.URL, spool Spool) error {
@@ -60,7 +62,7 @@ func gcsPersist(ctx context.Context, ep *url.URL, spool Spool) error {
 		return err
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	var wc = client.Bucket(cfg.bucket).Object(cfg.prefix + spool.ContentPath()).NewWriter(ctx)
+	var wc = client.Bucket(cfg.bucket).Object(cfg.prefix + cfg.rewritePath(spool.ContentPath())).NewWriter(ctx)
 
 	if spool.CompressionCodec == pb.CompressionCodec_GZIP_OFFLOAD_DECOMPRESSION {
 		wc.ContentEncoding = "gzip"
@@ -78,13 +80,13 @@ func gcsPersist(ctx context.Context, ep *url.URL, spool Spool) error {
 	return err
 }
 
-func gcsList(ctx context.Context, store pb.FragmentStore, ep *url.URL, prefix string, callback func(pb.Fragment)) error {
+func gcsList(ctx context.Context, store pb.FragmentStore, ep *url.URL, name pb.Journal, callback func(pb.Fragment)) error {
 	cfg, client, _, err := gcsClient(ep)
 	if err != nil {
 		return err
 	}
 	var (
-		it    = client.Bucket(cfg.bucket).Objects(ctx, &storage.Query{Prefix: cfg.prefix + prefix})
+		it    = client.Bucket(cfg.bucket).Objects(ctx, &storage.Query{Prefix: cfg.prefix + cfg.rewritePath(name.String()) + "/"})
 		strip = len(cfg.prefix)
 		obj   *storage.ObjectAttrs
 	)
@@ -160,7 +162,7 @@ func gcsRemove(ctx context.Context, ep *url.URL, fragment pb.Fragment) error {
 	if err != nil {
 		return err
 	}
-	return client.Bucket(cfg.bucket).Object(cfg.prefix + fragment.ContentPath()).Delete(ctx)
+	return client.Bucket(cfg.bucket).Object(cfg.prefix + cfg.rewritePath(fragment.ContentPath())).Delete(ctx)
 }
 
 var sharedGCS struct {

--- a/v2/pkg/fragment/store_s3.go
+++ b/v2/pkg/fragment/store_s3.go
@@ -50,7 +50,7 @@ func s3SignGET(ep *url.URL, fragment pb.Fragment, d time.Duration) (string, erro
 
 	var getObj = s3.GetObjectInput{
 		Bucket: aws.String(cfg.bucket),
-		Key:    aws.String(cfg.prefix + cfg.rewritePath(fragment.ContentPath())),
+		Key:    aws.String(cfg.rewritePath(cfg.prefix, fragment.ContentPath())),
 	}
 	var req, _ = client.GetObjectRequest(&getObj)
 	return req.Presign(d)
@@ -63,7 +63,7 @@ func s3Exists(ctx context.Context, ep *url.URL, fragment pb.Fragment) (bool, err
 	}
 	var headObj = s3.HeadObjectInput{
 		Bucket: aws.String(cfg.bucket),
-		Key:    aws.String(cfg.prefix + cfg.rewritePath(fragment.ContentPath())),
+		Key:    aws.String(cfg.rewritePath(cfg.prefix, fragment.ContentPath())),
 	}
 	if _, err = client.HeadObjectWithContext(ctx, &headObj); err == nil {
 		return true, nil
@@ -82,7 +82,7 @@ func s3Open(ctx context.Context, ep *url.URL, fragment pb.Fragment) (io.ReadClos
 
 	var getObj = s3.GetObjectInput{
 		Bucket: aws.String(cfg.bucket),
-		Key:    aws.String(cfg.prefix + cfg.rewritePath(fragment.ContentPath())),
+		Key:    aws.String(cfg.rewritePath(cfg.prefix, fragment.ContentPath())),
 	}
 	if resp, err := client.GetObjectWithContext(ctx, &getObj); err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func s3Persist(ctx context.Context, ep *url.URL, spool Spool) error {
 
 	var putObj = s3.PutObjectInput{
 		Bucket: aws.String(cfg.bucket),
-		Key:    aws.String(cfg.prefix + cfg.rewritePath(spool.ContentPath())),
+		Key:    aws.String(cfg.rewritePath(cfg.prefix, spool.ContentPath())),
 	}
 
 	if cfg.ACL != "" {
@@ -131,7 +131,7 @@ func s3List(ctx context.Context, store pb.FragmentStore, ep *url.URL, name pb.Jo
 
 	var list = s3.ListObjectsV2Input{
 		Bucket: aws.String(cfg.bucket),
-		Prefix: aws.String(cfg.prefix + cfg.rewritePath(name.String()) + "/"),
+		Prefix: aws.String(cfg.rewritePath(cfg.prefix, name.String()) + "/"),
 	}
 	var strip = len(cfg.prefix)
 

--- a/v2/pkg/fragment/stores.go
+++ b/v2/pkg/fragment/stores.go
@@ -144,11 +144,12 @@ type rewriterCfg struct {
 }
 
 // rewritePath replace the first occurrence of the find string with the replace
-// string, effectively rewriting the default Journal path. If find is empty or
-// not found, the original path is returned.
-func (cfg rewriterCfg) rewritePath(path string) string {
+// string in journal path |j| and appends it to the fragment store path |s|,
+// effectively rewriting the default Journal path. If find is empty or not
+// found, the original |j| is appended.
+func (cfg rewriterCfg) rewritePath(s, j string) string {
 	if cfg.Find == "" {
-		return path
+		return s+j
 	}
-	return strings.Replace(path, cfg.Find, cfg.Replace, 1)
+	return s+strings.Replace(j, cfg.Find, cfg.Replace, 1)
 }


### PR DESCRIPTION
When migrating from multiple Gazette clusters to a single one, it may be
desirable to not move existing fragments. However, this both forces the
name of the journal in the target cluster and may result in a name
conflict between two journals with the same name but different fragment
stores.

The "find"/"replace" query parameters implemented on "file", "s3", and
"gs" backends provides a workaround that avoids moving fragments.

For example, if previously there was

- `foo-topic/part-000` backed by `s3://bar-journals/`
- `foo-topic/part-000` backed by `gs://bar-journals/`

the two would collide in the target cluster despite being distinct
journals (unless one was renamed).

The example below shows how to give the journals different names in the
target cluster while still being backed by the existing fragments.

```
  name: "s3-foo-topic/"
  stores:
    - "s3://bar-journals/?find=s3-foo-topic&replace=foo-topic"
  children:
    - "s3-foo-topic/part-000"

  # ...

  name: "gs-foo-topic/"
  stores:
    - "gs://bar-journals/?find=gs-foo-topic&replace=foo-topic"
  children:
    - "gs-foo-topic/part-000"
```

Connects #138

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/144)
<!-- Reviewable:end -->
