### PR TITLE
clean up fragment store Remove function signature

### DIFF
--- a/v2/pkg/fragment/store_fs.go
+++ b/v2/pkg/fragment/store_fs.go
@@ -135,7 +135,8 @@ func fsList(store pb.FragmentStore, ep *url.URL, name pb.Journal, callback func(
 		})
 }
 
-func fsRemove(ep *url.URL, fragment pb.Fragment) error {
+func fsRemove(fragment pb.Fragment) error {
+	var ep = fragment.BackingStore.URL()
 	var cfg, err = newFsCfg(ep)
 	if err != nil {
 		return err

--- a/v2/pkg/fragment/store_gcs.go
+++ b/v2/pkg/fragment/store_gcs.go
@@ -157,8 +157,8 @@ func gcsClient(ep *url.URL) (cfg gcsCfg, client *storage.Client, opts storage.Si
 	return
 }
 
-func gcsRemove(ctx context.Context, ep *url.URL, fragment pb.Fragment) error {
-	cfg, client, _, err := gcsClient(ep)
+func gcsRemove(ctx context.Context, fragment pb.Fragment) error {
+	cfg, client, _, err := gcsClient(fragment.BackingStore.URL())
 	if err != nil {
 		return err
 	}

--- a/v2/pkg/fragment/store_s3.go
+++ b/v2/pkg/fragment/store_s3.go
@@ -152,8 +152,8 @@ func s3List(ctx context.Context, store pb.FragmentStore, ep *url.URL, name pb.Jo
 	})
 }
 
-func s3Remove(ctx context.Context, ep *url.URL, fragment pb.Fragment) error {
-	var cfg, client, err = s3Client(ep)
+func s3Remove(ctx context.Context, fragment pb.Fragment) error {
+	var cfg, client, err = s3Client(fragment.BackingStore.URL())
 	if err != nil {
 		return err
 	}

--- a/v2/pkg/fragment/stores.go
+++ b/v2/pkg/fragment/stores.go
@@ -108,17 +108,15 @@ func List(ctx context.Context, store pb.FragmentStore, name pb.Journal, callback
 
 // Remove |fragment| from |store|.
 func Remove(ctx context.Context, store pb.FragmentStore, fragment pb.Fragment) error {
-	var ep = store.URL()
-
-	switch ep.Scheme {
+	switch fragment.BackingStore.URL().Scheme {
 	case "s3":
-		return s3Remove(ctx, ep, fragment)
+		return s3Remove(ctx, fragment)
 	case "gs":
-		return gcsRemove(ctx, ep, fragment)
+		return gcsRemove(ctx, fragment)
 	case "file":
-		return fsRemove(ep, fragment)
+		return fsRemove(fragment)
 	default:
-		panic("unsupported scheme: " + ep.Scheme)
+		panic("unsupported scheme: " + fragment.BackingStore)
 	}
 }
 
@@ -134,7 +132,6 @@ func parseStoreArgs(ep *url.URL, args interface{}) error {
 	return nil
 }
 
-
 // rewriterCfg holds a find/replace pair, often populated by parseStoreArgs()
 // and provides a convenience function to rewrite the given path.
 //
@@ -149,7 +146,7 @@ type rewriterCfg struct {
 // found, the original |j| is appended.
 func (cfg rewriterCfg) rewritePath(s, j string) string {
 	if cfg.Find == "" {
-		return s+j
+		return s + j
 	}
-	return s+strings.Replace(j, cfg.Find, cfg.Replace, 1)
+	return s + strings.Replace(j, cfg.Find, cfg.Replace, 1)
 }


### PR DESCRIPTION
the backing store endpoint could be derived from the fragment object as needed so there is no need to pass in the endpoint to the `Remove` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/150)
<!-- Reviewable:end -->
