### PR TITLE
gazctl: add journals reset-head command

### DIFF
--- a/v2/cmd/gazctl/journals_reset_head.go
+++ b/v2/cmd/gazctl/journals_reset_head.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+
+	"github.com/LiveRamp/gazette/v2/pkg/client"
+	mbp "github.com/LiveRamp/gazette/v2/pkg/mainboilerplate"
+	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
+)
+
+type cmdJournalResetHead struct {
+	Selector string `long:"selector" short:"l" required:"true" description:"Label Selector query to filter on"`
+}
+
+func (cmd *cmdJournalResetHead) Execute([]string) error {
+	startup()
+
+	var err error
+	var ctx = context.Background()
+	var rjc = journalsCfg.Broker.RoutedJournalClient(ctx)
+
+	// Get the list of journals which match this selector.
+	var listRequest pb.ListRequest
+	listRequest.Selector, err = pb.ParseLabelSelector(cmd.Selector)
+	mbp.Must(err, "failed to parse label selector", "selector", cmd.Selector)
+
+	var listResp *pb.ListResponse
+	listResp, err = client.ListAllJournals(ctx, rjc, listRequest)
+	mbp.Must(err, "failed to resolved journals from selector", cmd.Selector)
+
+	// Query the largest indexed fragment offset of each journal, and reset the append offset to that head.
+	for _, journal := range listResp.Journals {
+		var r = client.NewReader(ctx, rjc, pb.ReadRequest{
+			Journal:      journal.Spec.Name,
+			Offset:       -1,
+			Block:        false,
+			MetadataOnly: true,
+		})
+		if _, err = r.Read(nil); err != client.ErrOffsetNotYetAvailable {
+			mbp.Must(err, "failed to read head of journal", "journal", journal.Spec.Name)
+		}
+		// Issue a zero-byte write at the indexed head.
+		var a = client.NewAppender(ctx, rjc, pb.AppendRequest{
+			Journal: journal.Spec.Name,
+			Offset:  r.Response.Offset,
+		})
+		mbp.Must(a.Close(), "failed to reset journal offset", "journal", journal.Spec.Name)
+	}
+	return nil
+}

--- a/v2/cmd/gazctl/main.go
+++ b/v2/cmd/gazctl/main.go
@@ -186,6 +186,42 @@ If not passed the default value is -1 which will read from the head of the journ
 	_ = addCmd(cmdJournals, "edit", "Edit journal specifications", journalsEditLongDesc, &cmdJournalsEdit{})
 	_ = addCmd(cmdShards, "edit", "Edit shard specifications", shardsEditLongDesc, &cmdShardsEdit{})
 
+	_ = addCmd(cmdJournals, "reset-head", "Reset journal append offset (disaster recovery)", `
+Reset the append offset of journals.
+
+Gazette appends are transactional: all brokers must agree on the exact offsets
+at which an append operation will be written into a journal. The offset is an
+explicit participate in the broker's transaction protocol. New participants are
+"caught up" on the current offset by participating in broker transactions, and
+brokers will delay releasing responsibility for a journal until all peers have
+participated in a synchronizing transaction. This makes Gazette tolerant to up
+to R-1 independent broker process failures, where R is the replication factor
+of the journal.
+
+However, disasters and human errors do happen, and if R or more independent
+failures occur, Gazette employs a fail-safe to minimize the potential for a
+journal offset to be written more than once: brokers require that the remote
+fragment index not include a fragment offset larger than the append offset known
+to replicating broker peers, and will refuse the append if this constraint is
+violated.
+
+Eg, If N >= R failures occur, then the set of broker peers of a journal will not
+have participated in an append transaction; their append offset will be zero,
+which is less than the maximum offset contained in the fragment store. The
+brokers will refuse all appends to preclude double-writing of an offset.
+
+This condition must be explicitly cleared by the Gazette operator using the
+reset-head command. The operator should delay running reset-head until absolutely
+confident that all journal fragments have been persisted to cloud storage (eg,
+because all previous broker processes have exited).
+
+Then, the effect of reset-head is to jump the append offset forward to the
+maximum indexed offset, allowing new append operations to proceed.
+
+reset-head is safe to run against journals which are in a fully consistent state,
+though it is likely to fail harmlessly if the journal is being actively written.
+`, &cmdJournalResetHead{})
+
 	mbp.MustParseConfig(parser, iniFilename)
 }
 

--- a/v2/pkg/allocator/flow_network_test.go
+++ b/v2/pkg/allocator/flow_network_test.go
@@ -41,6 +41,8 @@ func (s *FlowNetworkSuite) TestZoneScalingFactors(c *gc.C) {
 		{itemCount: 10, itemSlots: 40, expect: 39, zoneSlots: []int{19, 20}},
 		{itemCount: 10, itemSlots: 40, expect: 39, zoneSlots: []int{39}},
 		{itemCount: 10, itemSlots: 30, expect: 12, zoneSlots: []int{5, 4, 3}},
+		// Regression test case (issue #157).
+		{itemCount: 7, itemSlots: 21, expect: 21, zoneSlots: []int{2048, 1024}},
 	}
 	for _, tc := range cases {
 		var num, denom = zoneScalingFactors(tc.itemCount, tc.itemSlots, tc.zoneSlots)

--- a/v2/pkg/allocator/scenarios_test.go
+++ b/v2/pkg/allocator/scenarios_test.go
@@ -51,6 +51,56 @@ func (s *ScenariosSuite) TestInitialAllocation(c *gc.C) {
 	})
 }
 
+func (s *ScenariosSuite) TestInitialAllocationRegressionIssue157(c *gc.C) {
+	c.Skip("This test demonstrates the edge case of Issue 157, and currently fails.")
+
+	c.Check(insert(s.ctx, s.client, ""+
+		"/root/items/item-01", `{"R": 3}`,
+		"/root/items/item-02", `{"R": 3}`,
+		"/root/items/item-03", `{"R": 3}`,
+		"/root/items/item-04", `{"R": 3}`,
+		"/root/items/item-05", `{"R": 3}`,
+		"/root/items/item-06", `{"R": 3}`,
+		"/root/items/item-07", `{"R": 3}`,
+
+		"/root/members/zone-a#member-A1", `{"R": 1024}`,
+		"/root/members/zone-a#member-A2", `{"R": 1024}`,
+		"/root/members/zone-b#member-B1", `{"R": 1024}`,
+	), gc.IsNil)
+	c.Check(serveUntilIdle(c, s.ctx, s.client, s.ks), gc.Equals, 1)
+
+	// Expect Items are fully replicated, each Item spans both zones, and no Member ItemLimit is breached.
+	c.Check(keys(s.ks.Prefixed(s.ks.Root+AssignmentsPrefix)), gc.DeepEquals, []string{
+		"/root/assign/item-01#zone-a#member-A1#0",
+		"/root/assign/item-01#zone-a#member-A2#1",
+		"/root/assign/item-01#zone-b#member-B1#2",
+
+		"/root/assign/item-02#zone-a#member-A1#0",
+		"/root/assign/item-02#zone-a#member-A2#1",
+		"/root/assign/item-02#zone-b#member-B1#2",
+
+		"/root/assign/item-03#zone-a#member-A1#0",
+		"/root/assign/item-03#zone-a#member-A2#1",
+		"/root/assign/item-03#zone-b#member-B1#2",
+
+		"/root/assign/item-04#zone-a#member-A1#0",
+		"/root/assign/item-04#zone-a#member-A2#1",
+		"/root/assign/item-04#zone-b#member-B1#2",
+
+		"/root/assign/item-05#zone-a#member-A1#0",
+		"/root/assign/item-05#zone-a#member-A2#1",
+		"/root/assign/item-05#zone-b#member-B1#2",
+
+		"/root/assign/item-06#zone-a#member-A1#0",
+		"/root/assign/item-06#zone-a#member-A2#1",
+		"/root/assign/item-06#zone-b#member-B1#2",
+
+		"/root/assign/item-07#zone-a#member-A1#0",
+		"/root/assign/item-07#zone-a#member-A2#1",
+		"/root/assign/item-07#zone-b#member-B1#2",
+	})
+}
+
 func (s *ScenariosSuite) TestReplaceWhenNotConsistent(c *gc.C) {
 	c.Check(insert(s.ctx, s.client,
 		"/root/items/item-1", `{"R": 1}`,

--- a/v2/pkg/broker/append_api.go
+++ b/v2/pkg/broker/append_api.go
@@ -112,6 +112,12 @@ func serveAppend(stream pb.Journal_AppendServer, req *pb.AppendRequest, res reso
 	// unless the request provides an explicit offset.
 	if po := pln.spool.Fragment.End; po != offset && req.Offset == 0 {
 		res.replica.pipelineCh <- pln // Release |pln|.
+
+		log.WithFields(log.Fields{
+			"journal": req.Journal,
+			"offset":  pln.spool.Fragment.End,
+			"indexed": offset,
+		}).Warn("failing append because fragment index offset > append offset (was consistency lost?)")
 		return stream.SendAndClose(&pb.AppendResponse{Status: pb.Status_INDEX_HAS_GREATER_OFFSET, Header: res.Header})
 	} else if req.Offset == 0 {
 		// Use |offset| (== |po|).


### PR DESCRIPTION
reset-head resets the append offset to the maximum offset of selected
journals. Also add a log statement in the broker for greater visibility.

Tested on a local stack by:
 - running examples
 - running reset-head (effective no-op).
 - deleting all example journals, first preserving yaml
 - re-applying yaml
 - confirming that INDEX_HAS_GREATER_OFFSET errors were returned on attempted writes
 - running reset-head
 - confirming that write now proceed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/155)
<!-- Reviewable:end -->
