### PR TITLE
Update minio service name

### DIFF
--- a/v2/test/deploy_examples.sh
+++ b/v2/test/deploy_examples.sh
@@ -22,7 +22,7 @@ readonly GAZCTL="${DOCKER} run \
 
 # Create all test journals. Use `sed` to replace the MINIO_RELEASE token with the
 # correct Minio service address.
-sed -e "s/MINIO_RELEASE/$(helm_release ${BK_NAMESPACE} minio).${BK_NAMESPACE}/g" ${V2DIR}/test/examples.journalspace.yaml | \
+sed -e "s/MINIO_RELEASE/$(helm_release ${BK_NAMESPACE} minio)-minio.${BK_NAMESPACE}/g" ${V2DIR}/test/examples.journalspace.yaml | \
   BROKER_ADDRESS=$(release_address $(helm_release ${BK_NAMESPACE} gazette) gazette) ${GAZCTL} journals apply --specs /dev/stdin
 
 # Install a test "gazette-zonemap" ConfigMap in the namespace,


### PR DESCRIPTION
Minio did not use standard helm naming conventions in its helm chart, this has been fixed [here](https://github.com/helm/charts/commit/9874c2106664c79c763a08b30b2660fea4105eda) As a result of this change, the generated `journalspace` for the gazette examples will no longer resolve the fragment backends properly. This change updates the generated `journalspace` to properly reflect the new minio service name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/158)
<!-- Reviewable:end -->
