### PR TITLE
Update RocksDB from v5.14.2 to v5.17.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -695,12 +695,13 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:6ef99b772e9252c54e362af989aa0ad6be34f304c04e9d52c8431d94b4e2fe2d"
+  digest = "1:833adfd78777b99abd9fcf6d24e687b5f3c4faea8894ad50ab0eb60f351fdf5f"
   name = "github.com/tecbot/gorocksdb"
   packages = ["."]
   pruneopts = ""
-  revision = "22dabfda16ecbdd40858aca4e7898ee8d592d647"
+  revision = "690866229953e77b91d3eae1fa42206001c5c7c9"
   source = "https://github.com/LiveRamp/gorocksdb.git"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -1017,7 +1018,6 @@
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/types",
     "github.com/golang/protobuf/ptypes/duration",
-    "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/golang/snappy",
     "github.com/gorilla/mux",
     "github.com/gorilla/schema",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,5 +67,5 @@ required = [
 # We require that gorocksdb match our RocksDB version pin (currently 5.17.2)
 [[constraint]]
   name = "github.com/tecbot/gorocksdb"
-  revision = "22dabfda16ecbdd40858aca4e7898ee8d592d647"
+  version = "v1.2.0"
   source = "https://github.com/LiveRamp/gorocksdb.git"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   name = "github.com/gogo/protobuf"
   revision = "e14cafb6a2c249986e51c4b65c3206bf18578715"
 
-# We require that gorocksdb match our RocksDB version pin (currently 5.14.2)
+# We require that gorocksdb match our RocksDB version pin (currently 5.17.2)
 [[constraint]]
   name = "github.com/tecbot/gorocksdb"
   revision = "22dabfda16ecbdd40858aca4e7898ee8d592d647"

--- a/v2/build/Dockerfile
+++ b/v2/build/Dockerfile
@@ -2,7 +2,7 @@
 # RocksDB library, its tools, and dependencies.
 FROM golang:1.11 AS base
 
-ARG ROCKSDB_VERSION=5.14.2
+ARG ROCKSDB_VERSION=5.17.2
 ARG ZSTD_VERSION=1.3.5
 
 # Install dependencies for building & running RocksDB.


### PR DESCRIPTION
Ultimately we want to set the TTL for level compaction. This option was
immutable in v5.14.2 and made mutable in v5.15.x. Since we can only set
this option dynamically with the C bindings (after opening the DB), we
must upgrade our version of RocksDB.

Connects #112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/160)
<!-- Reviewable:end -->
