### PR TITLE
Add max-txn-size flag to gazctl

### DIFF
--- a/v2/cmd/gazctl/journals_apply.go
+++ b/v2/cmd/gazctl/journals_apply.go
@@ -33,10 +33,10 @@ func (cmd *cmdJournalsApply) Execute([]string) error {
 	}
 
 	var ctx = context.Background()
-	resp, err := client.ApplyJournals(ctx, journalsCfg.Broker.JournalClient(ctx), req)
+	var resp, err = client.ApplyJournalsInBatches(ctx, journalsCfg.Broker.JournalClient(ctx), req, cmd.MaxTxnSize)
 	mbp.Must(err, "failed to apply journals")
-
 	log.WithField("rev", resp.Header.Etcd.Revision).Info("successfully applied")
+
 	return nil
 }
 

--- a/v2/cmd/gazctl/journals_edit.go
+++ b/v2/cmd/gazctl/journals_edit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LiveRamp/gazette/v2/cmd/gazctl/editor"
 	"github.com/LiveRamp/gazette/v2/pkg/client"
+	mbp "github.com/LiveRamp/gazette/v2/pkg/mainboilerplate"
 	"github.com/LiveRamp/gazette/v2/pkg/protocol/journalspace"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -54,11 +55,9 @@ func (cmd *cmdJournalsEdit) applySpecs(b []byte) error {
 	}
 
 	var ctx = context.Background()
-	if resp, err := client.ApplyJournals(ctx, journalsCfg.Broker.JournalClient(ctx), req); err != nil {
-		return err
-	} else {
-		log.WithField("rev", resp.Header.Etcd.Revision).Info("successfully applied")
-	}
+	var resp, err = client.ApplyJournalsInBatches(ctx, journalsCfg.Broker.JournalClient(ctx), req, cmd.MaxTxnSize)
+	mbp.Must(err, "failed to apply journals")
+	log.WithField("rev", resp.Header.Etcd.Revision).Info("successfully applied")
 
 	return nil
 }

--- a/v2/cmd/gazctl/shards_apply.go
+++ b/v2/cmd/gazctl/shards_apply.go
@@ -30,10 +30,10 @@ func (cmd *cmdShardsApply) Execute([]string) error {
 	}
 
 	var ctx = context.Background()
-	resp, err := consumer.ApplyShards(ctx, shardsCfg.Consumer.ShardClient(ctx), req)
+	var resp, err = consumer.ApplyShardsInBatches(ctx, shardsCfg.Consumer.ShardClient(ctx), req, cmd.MaxTxnSize)
 	mbp.Must(err, "failed to apply shards")
-
 	log.WithField("rev", resp.Header.Etcd.Revision).Info("successfully applied")
+
 	return nil
 }
 

--- a/v2/pkg/consumer/consumer_stub_test.go
+++ b/v2/pkg/consumer/consumer_stub_test.go
@@ -1,0 +1,78 @@
+package consumer
+
+import (
+	"context"
+
+	"github.com/LiveRamp/gazette/v2/pkg/server"
+	gc "github.com/go-check/check"
+	"google.golang.org/grpc"
+)
+
+// loopbackServer serves a ShardServer over a loopback, for use within tests.
+type loopbackServer struct {
+	*server.Server
+	Conn *grpc.ClientConn
+}
+
+// newLoopbackServer returns a loopbackServer of the provided ShardServer.
+func newLoopbackServer(ctx context.Context, ss ShardServer) loopbackServer {
+	var srv, err = server.New("127.0.0.1", 0)
+	if err != nil {
+		panic(err)
+	}
+	RegisterShardServer(srv.GRPCServer, ss)
+	var conn = srv.MustGRPCLoopback()
+
+	// Arrange to stop the server when |ctx| is cancelled.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+		srv.GracefulStop()
+	}()
+	go srv.MustServe()
+
+	return loopbackServer{Server: srv, Conn: conn}
+}
+
+// MustClient returns a ShardClient of the test loopbackServer.
+func (s loopbackServer) MustClient() ShardClient { return NewShardClient(s.Conn) }
+
+// shardServerStub stubs the read and write loops of ShardServer RPCs.
+type shardServerStub struct {
+	loopbackServer
+	c *gc.C
+
+	StatFunc     func(context.Context, *StatRequest) (*StatResponse, error)
+	ListFunc     func(context.Context, *ListRequest) (*ListResponse, error)
+	ApplyFunc    func(context.Context, *ApplyRequest) (*ApplyResponse, error)
+	GetHintsFunc func(context.Context, *GetHintsRequest) (*GetHintsResponse, error)
+}
+
+// newShardServerStub returns a shardServerStub instance served by a local GRPC server.
+func newShardServerStub(ctx context.Context, c *gc.C) *shardServerStub {
+	var s = &shardServerStub{
+		c: c,
+	}
+	s.loopbackServer = newLoopbackServer(ctx, s)
+	return s
+}
+
+// Stat implements the shardServerStub interface by proxying through StatFunc.
+func (s *shardServerStub) Stat(ctx context.Context, req *StatRequest) (*StatResponse, error) {
+	return s.StatFunc(ctx, req)
+}
+
+// List implements the shardServerStub interface by proxying through ListFunc.
+func (s *shardServerStub) List(ctx context.Context, req *ListRequest) (*ListResponse, error) {
+	return s.ListFunc(ctx, req)
+}
+
+// Apply implements the shardServerStub interface by proxying through ApplyFunc.
+func (s *shardServerStub) Apply(ctx context.Context, req *ApplyRequest) (*ApplyResponse, error) {
+	return s.ApplyFunc(ctx, req)
+}
+
+// GetHints implements the shardServerStub interface by proxying through GetHintsFunc.
+func (s *shardServerStub) GetHints(ctx context.Context, req *GetHintsRequest) (*GetHintsResponse, error) {
+	return s.GetHintsFunc(ctx, req)
+}


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/161)
<!-- Reviewable:end -->
Connects #154
Connects #159


Please review commit by commit.
First commit:
There is an outstanding ticket (#154) to create a loopback server for testing against a consumer. This implements a basic loopback server in the model of the broker loopback server. This is a first pass implementation and sought to solve the problems introduced in writing tests for the second commit. As this testing tool is used more I expect it will be expanded upon. 

Second commit:
Add a max transaction size flag to all of the apply/edit commands in gazctl. 