### PR TITLE
client: AppendService aborts AsyncAppends when context is cancelled.

### DIFF
--- a/v2/pkg/consumer/lifecycle.go
+++ b/v2/pkg/consumer/lifecycle.go
@@ -155,7 +155,11 @@ func consumeMessages(shard Shard, store Store, app Application, etcd *clientv3.C
 	for {
 		select {
 		case <-hintsCh:
-			if err = storeRecordedHints(shard, store.Recorder().BuildHints(), etcd); err != nil {
+			var hints recoverylog.FSMHints
+			if hints, err = store.Recorder().BuildHints(); err == nil {
+				err = storeRecordedHints(shard, hints, etcd)
+			}
+			if err != nil {
 				err = extendErr(err, "storeRecordedHints")
 				return
 			}

--- a/v2/pkg/consumer/lifecycle_test.go
+++ b/v2/pkg/consumer/lifecycle_test.go
@@ -58,7 +58,8 @@ func (s *LifecycleSuite) TestRecoveryOfNonEmptyLog(c *gc.C) {
 	}
 	c.Check(r.app.FinalizeTxn(r, r.store), gc.IsNil)
 	c.Check(r.store.Flush(map[pb.Journal]int64{sourceA: 123, sourceB: 456}), gc.IsNil)
-	c.Check(storeRecordedHints(r, r.store.Recorder().BuildHints(), r.etcd), gc.IsNil)
+	var hints, _ = r.store.Recorder().BuildHints()
+	c.Check(storeRecordedHints(r, hints, r.etcd), gc.IsNil)
 
 	// Reset for the next player.
 	r.store.Destroy()

--- a/v2/pkg/consumer/replica.go
+++ b/v2/pkg/consumer/replica.go
@@ -61,7 +61,7 @@ func NewReplica(app Application, ks *keyspace.KeySpace, etcd *clientv3.Client, r
 		player:        recoverylog.NewPlayer(),
 		ks:            ks,
 		etcd:          etcd,
-		journalClient: client.NewAppendService(context.Background(), rjc),
+		journalClient: client.NewAppendService(ctx, rjc),
 	}
 	return r
 }

--- a/v2/pkg/consumer/shard_api.go
+++ b/v2/pkg/consumer/shard_api.go
@@ -40,7 +40,8 @@ func (srv *Service) Stat(ctx context.Context, req *StatRequest) (*StatResponse, 
 		// fetched offsets may still be in progress. Block on a WeakBarrier so
 		// that, when we return to the caller, they're assured that all writes
 		// related to processing through the offsets have also committed.
-		<-res.Store.Recorder().WeakBarrier().Done()
+		var txn = res.Store.Recorder().WeakBarrier()
+		_, err = <-txn.Done(), txn.Err()
 	}
 	return resp, err
 }

--- a/v2/pkg/recoverylog/playback_test.go
+++ b/v2/pkg/recoverylog/playback_test.go
@@ -390,7 +390,7 @@ func (s *PlaybackSuite) TestPlayWithFinishAtWriteHead(c *gc.C) {
 	// Start a Recorder, and produce a set of initial hints.
 	var rec = NewRecorder(recFSM, anAuthor, "/strip", bk)
 	var f = rec.RecordCreate("/strip/foo/bar")
-	var hints = rec.BuildHints()
+	var hints, _ = rec.BuildHints()
 
 	// Record more content not captured in |hints|.
 	f.RecordWrite([]byte("hello"))
@@ -439,7 +439,7 @@ func (s *PlaybackSuite) TestPlayWithInjectHandoff(c *gc.C) {
 	// Start a Recorder, and two Players from initial Recorder hints.
 	var rec = NewRecorder(recFSM, anAuthor, "/strip", bk)
 	var f = rec.RecordCreate("/strip/foo/bar")
-	var hints = rec.BuildHints()
+	var hints, _ = rec.BuildHints()
 
 	// |handoffPlayer| will inject a hand-off noop to take ownership of the log.
 	var handoffPlayer = NewPlayer()
@@ -488,7 +488,9 @@ func (s *PlaybackSuite) TestPlayWithInjectHandoff(c *gc.C) {
 	c.Check(handoffPlayer.FSM.BuildHints(), gc.DeepEquals, tailPlayer.FSM.BuildHints())
 
 	// Expect players have branched from |rec|'s view of history.
-	c.Check(rec.BuildHints(), gc.Not(gc.DeepEquals), tailPlayer.FSM.BuildHints())
+	hints, err = rec.BuildHints()
+	c.Check(hints, gc.Not(gc.DeepEquals), tailPlayer.FSM.BuildHints())
+	c.Check(err, gc.IsNil)
 }
 
 func (s *PlaybackSuite) TestPlayWithUnusedHints(c *gc.C) {
@@ -512,7 +514,7 @@ func (s *PlaybackSuite) TestPlayWithUnusedHints(c *gc.C) {
 	rec.RecordCreate("/strip/baz").RecordWrite([]byte("bing"))
 
 	// Tweak hints by adding an Fnode & offset which was not actually recorded.
-	var hints = rec.BuildHints()
+	var hints, _ = rec.BuildHints()
 	{
 		var txn = bk.StartAppend(aRecoveryLog) // Determine log head.
 		c.Assert(txn.Release(), gc.IsNil)

--- a/v2/pkg/recoverylog/recorder_afero.go
+++ b/v2/pkg/recoverylog/recorder_afero.go
@@ -104,8 +104,9 @@ func (r recordedAferoFile) Sync() error {
 	if err := r.File.Sync(); err != nil {
 		return err
 	}
-	<-r.Recorder.StrongBarrier().Done()
-	return nil
+	var txn = r.Recorder.StrongBarrier()
+	<-txn.Done()
+	return txn.Err()
 }
 
 func (r recordedAferoFile) Truncate(int64) error {

--- a/v2/pkg/recoverylog/recorder_rocksdb_test.go
+++ b/v2/pkg/recoverylog/recorder_rocksdb_test.go
@@ -29,7 +29,7 @@ func (s *RecordedRocksDBSuite) TestSimpleStopAndStart(c *gc.C) {
 	replica1.put(c, "key1", "value one")
 	replica1.put(c, "key2", "value2")
 
-	var hints = replica1.recorder.BuildHints()
+	var hints, _ = replica1.recorder.BuildHints()
 
 	// |replica1| was initialized from empty hints and began writing at the
 	// recoverylog head (offset -1). However, expect that the produced hints
@@ -74,7 +74,7 @@ func (s *RecordedRocksDBSuite) TestWarmStandbyHandoff(c *gc.C) {
 	defer replica3.teardown(c)
 
 	replica1.startWriting(c, aRecoveryLog)
-	var hints = replica1.recorder.BuildHints()
+	var hints, _ = replica1.recorder.BuildHints()
 
 	// Both replicas begin reading at the same time.
 	replica2.startReading(c, hints)
@@ -124,7 +124,8 @@ func (s *RecordedRocksDBSuite) TestResolutionOfConflictingWriters(c *gc.C) {
 
 	// |replica1| begins as primary.
 	replica1.startWriting(c, aRecoveryLog)
-	replica2.startReading(c, replica1.recorder.BuildHints())
+	var hints, _ = replica1.recorder.BuildHints()
+	replica2.startReading(c, hints)
 	replica1.put(c, "key one", "value one")
 
 	// |replica2| now becomes live. |replica1| and |replica2| intersperse writes.
@@ -147,9 +148,12 @@ func (s *RecordedRocksDBSuite) TestResolutionOfConflictingWriters(c *gc.C) {
 	var replica4 = NewTestReplica(c, bk)
 	defer replica4.teardown(c)
 
-	replica3.startReading(c, replica1.recorder.BuildHints())
+	hints, _ = replica1.recorder.BuildHints()
+	replica3.startReading(c, hints)
 	replica3.makeLive(c)
-	replica4.startReading(c, replica2.recorder.BuildHints())
+
+	hints, _ = replica2.recorder.BuildHints()
+	replica4.startReading(c, hints)
 	replica4.makeLive(c)
 
 	// Expect |replica3| recovered |replica1| history.


### PR DESCRIPTION
Update all call-sites of AsyncAppend.Done with appropriate handling or
plumbing for AsyncAppend.Err.

consumer.NewReplica now creates an AppendService using the replica context,
and not context.Background, with the implication that all outstanding appends
are aborted immediately along with the replica.

Issue #163

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/168)
<!-- Reviewable:end -->
