### PR TITLE
allocator: add "Overflow" node to network structure

### DIFF
--- a/v2/pkg/allocator/flow_network_test.go
+++ b/v2/pkg/allocator/flow_network_test.go
@@ -88,11 +88,12 @@ func (s *FlowNetworkSuite) TestFlowOverSimpleFixture(c *gc.C) {
 		MBar = &fn.members[0]
 		MFoo = &fn.members[1]
 		MBaz = &fn.members[2]
+		OF   = &fn.overflow
 		T    = &fn.sink
 	)
 
 	// Verify Source Arcs.
-	verifyNode(c, S, &pr.Node{ID: 0, Height: 11, Arcs: []pr.Arc{
+	verifyNode(c, S, &pr.Node{ID: 0, Height: 12, Arcs: []pr.Arc{
 		{Capacity: 2, Priority: 2, Target: I1},
 		{Capacity: 1, Priority: 2, Target: I2},
 	}})
@@ -130,6 +131,7 @@ func (s *FlowNetworkSuite) TestFlowOverSimpleFixture(c *gc.C) {
 	}})
 	verifyNode(c, MBaz, &pr.Node{ID: 2, Height: 1, Arcs: []pr.Arc{
 		{Capacity: 2, Priority: 2, Target: T},
+		{Capacity: 1, Priority: 0, Target: OF},
 	}})
 
 	// Solve the flow network for maximum flow.

--- a/v2/pkg/allocator/scenarios_test.go
+++ b/v2/pkg/allocator/scenarios_test.go
@@ -52,8 +52,6 @@ func (s *ScenariosSuite) TestInitialAllocation(c *gc.C) {
 }
 
 func (s *ScenariosSuite) TestInitialAllocationRegressionIssue157(c *gc.C) {
-	c.Skip("This test demonstrates the edge case of Issue 157, and currently fails.")
-
 	c.Check(insert(s.ctx, s.client, ""+
 		"/root/items/item-01", `{"R": 3}`,
 		"/root/items/item-02", `{"R": 3}`,


### PR DESCRIPTION
The allocator flow-network scales member capacities via calculated zone scaling
factors, which are designed to encourage appropriate balancing of items across
members.

But, we've seen edge cases with this scaling where a larger number of items does
not fully allocate across a smaller number of members, each having large
capacities. I suspect these cases are impossible to detect ahead of time,
without actually running push/relabel.

The core problem is we're artifically limiting the capacity of members in the
flow network. This PR undoes that limitation but preserves the incentive to
allocate items evenly across members, by introducing an "Overflow" node. Each
Member node having remaining capacity beyond it's scaled capacity, expresses
that excess via an arc to the Overflow. But, the Overflow node is initialized
with a large height: in fact, the precise height which makes it the last
alternative for dealing with flow excess before that excess is instead pushed
back to the Source (terminating the algorithm).

Fixes #157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/169)
<!-- Reviewable:end -->
