### PR TITLE
gazctl shards list takes --lag flag

### DIFF
--- a/v2/cmd/gazctl/main.go
+++ b/v2/cmd/gazctl/main.go
@@ -33,7 +33,8 @@ var (
 		Broker mbp.ClientConfig `group:"Broker" namespace:"broker" env-namespace:"BROKER"`
 	})
 	shardsCfg = new(struct {
-		Consumer mbp.AddressConfig `group:"Consumer" namespace:"consumer" env-namespace:"CONSUMER"`
+		Consumer mbp.ClientConfig `group:"Consumer" namespace:"consumer" env-namespace:"CONSUMER"`
+		Broker   mbp.ClientConfig `group:"Broker" namespace:"broker" env-namespace:"BROKER"`
 	})
 
 	parser = flags.NewParser(baseCfg, flags.Default)


### PR DESCRIPTION
gazctl shards list now takes `--lag` flag to see lag per source journal. Example:

```
+--------------------------+---------+-------------------------------------------------------+
|            ID            | STATUS  |                          LAG                          |
+--------------------------+---------+-------------------------------------------------------+
| c8d5b53b975c8d24b178bddb | PRIMARY | some/valid/journal/name/part-004:516583220768 |
+--------------------------+---------+-------------------------------------------------------+
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/176)
<!-- Reviewable:end -->


Connects #175 