### PR TITLE
Change how "gazctl {journals,shards} apply" takes stdin

### DIFF
--- a/v2/cmd/gazctl/main.go
+++ b/v2/cmd/gazctl/main.go
@@ -59,7 +59,7 @@ type ListConfig struct {
 
 // ApplyConfig is common configuration of apply operations.
 type ApplyConfig struct {
-	SpecsPath  string `long:"specs" description:"Path to specifications file to apply. Stdin is used if not set"`
+	SpecsPath  string `long:"specs" required:"true" description:"Path to specifications file to apply. Provide a dash (-) to use stdin."`
 	DryRun     bool   `long:"dry-run" description:"Perform a dry-run of the apply"`
 	MaxTxnSize int    `long:"max-txn-size" default:"0" description:"maximum number of specs to be processed within an apply transaction. If 0, the default, all changes are issued in a single transaction"`
 }
@@ -79,10 +79,10 @@ func (cfg ApplyConfig) decode(into interface{}) error {
 	var buffer []byte
 	var err error
 
-	if cfg.SpecsPath != "" {
-		buffer, err = ioutil.ReadFile(cfg.SpecsPath)
-	} else {
+	if cfg.SpecsPath == "-" {
 		buffer, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		buffer, err = ioutil.ReadFile(cfg.SpecsPath)
 	}
 	mbp.Must(err, "failed to read YAML input")
 

--- a/v2/test/deploy_examples.sh
+++ b/v2/test/deploy_examples.sh
@@ -23,7 +23,7 @@ readonly GAZCTL="${DOCKER} run \
 # Create all test journals. Use `sed` to replace the MINIO_RELEASE token with the
 # correct Minio service address.
 sed -e "s/MINIO_RELEASE/$(helm_release ${BK_NAMESPACE} minio)-minio.${BK_NAMESPACE}/g" ${V2DIR}/test/examples.journalspace.yaml | \
-  BROKER_ADDRESS=$(release_address $(helm_release ${BK_NAMESPACE} gazette) gazette) ${GAZCTL} journals apply --specs /dev/stdin
+  BROKER_ADDRESS=$(release_address $(helm_release ${BK_NAMESPACE} gazette) gazette) ${GAZCTL} journals apply --specs -
 
 # Install a test "gazette-zonemap" ConfigMap in the namespace,
 # if one doesn't already exist.
@@ -62,7 +62,7 @@ EOF
 
 # Create shards by piping the enumeration to `gazctl shards apply` with the stream-sum service address.
 stream_sum_shards | \
-  CONSUMER_ADDRESS=$(release_address $(helm_release ${NAMESPACE} stream-sum) summer) ${GAZCTL} shards apply --specs /dev/stdin
+  CONSUMER_ADDRESS=$(release_address $(helm_release ${NAMESPACE} stream-sum) summer) ${GAZCTL} shards apply --specs -
 
 # Be a jerk and delete all gazette & stream-sum consumer pods a few times while
 # verification jobs are still running. Expect this breaks nothing, and all
@@ -106,4 +106,4 @@ EOF
 
 # Create shards by piping the enumeration to `gazctl shards apply` with the word-count service address.
 word_count_shards | \
-  CONSUMER_ADDRESS=$(release_address $(helm_release ${NAMESPACE} word-count) counter) ${GAZCTL} shards apply --specs /dev/stdin
+  CONSUMER_ADDRESS=$(release_address $(helm_release ${NAMESPACE} word-count) counter) ${GAZCTL} shards apply --specs -


### PR DESCRIPTION
Previously, `journals apply` and `shards apply` subcommands read from
stdin if the `--specs` option was not provided. This lead to the command
appearing hung if a user passed a file name but forgot to use `--specs`.
Stdin would be used and the filename, given as an arg, would be silently
ignored.

Taking a cue from `kubectl apply -f`, the `--specs` option is now
required. `--specs -` will read from stdin.

Connects #178

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/182)
<!-- Reviewable:end -->
