### PR TITLE
wait after announcing for allocator to resolve (WIP)

### DIFF
--- a/v2/pkg/allocator/announce.go
+++ b/v2/pkg/allocator/announce.go
@@ -35,6 +35,8 @@ func Announce(etcd *clientv3.Client, key, value string, lease clientv3.LeaseID) 
 		}
 
 		if err == nil {
+			// Sleep for some amount of time and wait for the allocator to resolve.
+			time.Sleep(announceConflictRetryInterval)
 			return &Announcement{
 				Key:      key,
 				Revision: resp.Header.Revision,

--- a/v2/pkg/mainboilerplate/service.go
+++ b/v2/pkg/mainboilerplate/service.go
@@ -55,7 +55,7 @@ func AnnounceServeAndAllocate(etcd EtcdContext, srv *server.Server, state *alloc
 	Must(spec.Validate(), "member specification validation error")
 
 	var ann = allocator.Announce(etcd.Etcd, state.LocalKey, spec.MarshalString(), etcd.Session.Lease())
-	Must(state.KS.Load(context.Background(), etcd.Etcd, ann.Revision), "failed to load KeySpace")
+	Must(state.KS.Load(context.Background(), etcd.Etcd, 0), "failed to load KeySpace")
 
 	// Register a signal handler which zeros our advertised limit in Etcd.
 	// Upon seeing this, Allocator will work to discharge all of our assigned


### PR DESCRIPTION
This PR is a quick fix attempt at solving an issue wherein clusters above some size cannot be deployed because at bootstrap we see errors such as the following:
```
{
    "err": "etcd Revision mismatch (expected = 48112, got 48114)",
    "level": "panic",
    "msg": "failed to load KeySpace",
    "time": "2019-03-20T17:53:44Z"
}
```
What we suspect might be going on is that there is a race condition where the broker announces itself and then attempts to fetch a snapshot of the keyspace at a version which has been overwritten by the allocator. The broker will panic and restart and get stuck in a loop. Because we are using etcd leases all the work done by the allocator is removed, and then when the broker is restarted the allocator must recalculate the topology and the race condition fails again. 

What I am suggesting here is two things:
1) Wait 10 seconds after announcing for the allocator to resolve
2) Rather than use the etcd version which was returned during the announcement, just use 0, the idea being that if the allocator has finished resolving the new topology then just grab that version of the etcd keyspace. There is still race condition here where the allocator may not have derived a new topology, however using the "latest" version of the keyspace gives you a better chance in the race condition.

The aim of the PR was to try to solve the issue with the minimal amount of code changes. There might be more elegant ways to do this but here I am optimizing for as few lines of code changed as possible. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/185)
<!-- Reviewable:end -->
