### PR TITLE
Fix store operation metrics

### DIFF
--- a/v2/pkg/fragment/stores.go
+++ b/v2/pkg/fragment/stores.go
@@ -128,8 +128,9 @@ func parseStoreArgs(ep *url.URL, args interface{}) error {
 func instrumentStoreOp(provider, op string, err error) {
 	if err != nil {
 		metrics.StoreRequestTotal.WithLabelValues(provider, op, metrics.Fail).Inc()
+	} else {
+		metrics.StoreRequestTotal.WithLabelValues(provider, op, metrics.Ok).Inc()
 	}
-	metrics.StoreRequestTotal.WithLabelValues(provider, op, metrics.Ok).Inc()
 }
 
 // rewriterCfg holds a find/replace pair, often populated by parseStoreArgs()


### PR DESCRIPTION
"Ok" counters for store operations were erroneously being incremented on
both "Fail"s and "Ok"s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/192)
<!-- Reviewable:end -->
