### PR TITLE
Remove extraneous warnings from GCS backed stores

### DIFF
--- a/v2/pkg/fragment/store_gcs.go
+++ b/v2/pkg/fragment/store_gcs.go
@@ -96,12 +96,30 @@ func (s *gcsBackend) List(ctx context.Context, store pb.FragmentStore, ep *url.U
 		return err
 	}
 	var (
-		it    = client.Bucket(cfg.bucket).Objects(ctx, &storage.Query{Prefix: cfg.rewritePath(cfg.prefix, name.String()) + "/"})
+		q = storage.Query{
+			Prefix: cfg.rewritePath(cfg.prefix, name.String()) + "/",
+			// Gazette stores all of a journal's fragment files in a flat
+			// structure. Providing a delimiter excludes files in
+			// subdirectories from the query results because they will be
+			// collapsed into a single synthetic "directory entry".
+			Delimiter: "/",
+		}
+		it    = client.Bucket(cfg.bucket).Objects(ctx, &q)
 		strip = len(cfg.prefix)
 		obj   *storage.ObjectAttrs
 	)
 	for obj, err = it.Next(); err == nil; obj, err = it.Next() {
-		if frag, err2 := pb.ParseContentPath(obj.Name[strip:]); err2 != nil {
+		if obj.Name[strip:] == q.Prefix || obj.Prefix != "" {
+			// The parent directory is included in the results because it
+			// matches the prefix. Additionally, if there are subdirectories,
+			// they will be represented by synthetic "directory entries". Both
+			// of these types of objects should be ignored as they never
+			// represent fragment files.
+			//
+			// See:
+			// - https://cloud.google.com/storage/docs/json_api/v1/objects/list
+			// - https://godoc.org/cloud.google.com/go/storage#ObjectAttrs.Prefix
+		} else if frag, err2 := pb.ParseContentPath(obj.Name[strip:]); err2 != nil {
 			log.WithFields(log.Fields{"bucket": cfg.bucket, "name": obj.Name, "err": err2}).Warning("parsing fragment")
 		} else if obj.Size == 0 && frag.ContentLength() > 0 {
 			log.WithFields(log.Fields{"bucket": cfg.bucket, "name": obj.Name}).Warning("zero-length fragment")


### PR DESCRIPTION
With this change, gcsBackend#List ignores objects that represent
directories when iterating through the objects of a bucket for a
journal. Such objects never represent fragment files and attempting to
parse their names as such will almost certainly fail, writing a warning
to the logs when, in fact, everything is as expected.

Connects: #194

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/gazette/195)
<!-- Reviewable:end -->
